### PR TITLE
mysql: Update sql mode default

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -399,7 +399,7 @@ var AllColumnPrivs = []PrivilegeType{SelectPriv, InsertPriv, UpdatePriv}
 const AllPrivilegeLiteral = "ALL PRIVILEGES"
 
 // DefaultSQLMode for GLOBAL_VARIABLES
-const DefaultSQLMode = "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"
+const DefaultSQLMode = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
 
 // DefaultLengthOfMysqlTypes is the map for default physical length of MySQL data types.
 // See http://dev.mysql.com/doc/refman/5.7/en/storage-requirements.html

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -506,6 +506,11 @@ func (m SQLMode) HasIgnoreSpaceMode() bool {
 	return m&ModeIgnoreSpace == ModeIgnoreSpace
 }
 
+// HasNoAutoCreateUserMode detects if 'NO_AUTO_CREATE_USER' mode is set in SQLMode
+func (m SQLMode) HasNoAutoCreateUserMode() bool {
+	return m&ModeNoAutoCreateUser == ModeNoAutoCreateUser
+}
+
 // consts for sql modes.
 const (
 	ModeNone        SQLMode = 0

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -506,11 +506,6 @@ func (m SQLMode) HasIgnoreSpaceMode() bool {
 	return m&ModeIgnoreSpace == ModeIgnoreSpace
 }
 
-// HasNoAutoCreateUserMode detects if 'NO_AUTO_CREATE_USER' mode is set in SQLMode
-func (m SQLMode) HasNoAutoCreateUserMode() bool {
-	return m&ModeNoAutoCreateUser == ModeNoAutoCreateUser
-}
-
 // consts for sql modes.
 const (
 	ModeNone        SQLMode = 0


### PR DESCRIPTION
This PR updates the SQL Mode to include only_full_group by and no_auto_create_user.

It fixes https://github.com/pingcap/tidb/issues/8129 and partially addresses https://github.com/pingcap/tidb/issues/8128

It depends on: https://github.com/pingcap/tidb/pull/8163