### PR TITLE
parser: add driver import check & example

### DIFF
--- a/parser_example_test.go
+++ b/parser_example_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser_test
+
+import (
+	"fmt"
+	"github.com/pingcap/parser"
+	// 0. import parser_driver implemented by TiDB(user also can implement own driver by self).
+	_ "github.com/pingcap/tidb/types/parser_driver"
+)
+
+// This example show how to parse a text sql into ast.
+func Example_parseSQL() {
+
+	// 1. Create a parser, this is a NOT thread-safe but heavy object,
+	// it is better to reuse it in thread-safe way as possible  as we can.
+	p := parser.New()
+
+	// 2. Parse a text SQL into AST([]ast.StmtNode)
+	stmtNodes, err := p.Parse("select * from tbl where id = 1", "", "")
+
+	// 3. Use AST to do cool things~
+	fmt.Println(stmtNodes[0], err)
+}

--- a/parser_example_test.go
+++ b/parser_example_test.go
@@ -23,6 +23,9 @@ import (
 // This example show how to parse a text sql into ast.
 func Example_parseSQL() {
 
+	// 0. make sure import parser_driver implemented by TiDB(user also can implement own driver by self).
+	// import _ "github.com/pingcap/tidb/types/parser_driver" in import part.
+
 	// 1. Create a parser, this is a NOT thread-safe but heavy object,
 	// it is better to reuse it in thread-safe way as possible  as we can.
 	p := parser.New()

--- a/parser_example_test.go
+++ b/parser_example_test.go
@@ -25,13 +25,15 @@ func Example_parseSQL() {
 	// 0. make sure import parser_driver implemented by TiDB(user also can implement own driver by self).
 	// and add `import _ "github.com/pingcap/tidb/types/parser_driver"` in the head of file.
 
-	// 1. Create a parser, this is a NOT thread-safe but heavy object,
-	// it is better to reuse it in thread-safe way as possible as we can.
+	// 1. Create a parser. The parser is NOT goroutine safe and should
+	// not be shared among multiple goroutines. However, parser is also
+	// heavy, so each goroutine should reuse its own local instance if
+	// possible.
 	p := parser.New()
 
-	// 2. Parse a text SQL into AST([]ast.StmtNode)
+	// 2. Parse a text SQL into AST([]ast.StmtNode).
 	stmtNodes, err := p.Parse("select * from tbl where id = 1", "", "")
 
-	// 3. Use AST to do cool thing~
+	// 3. Use AST to do cool things.
 	fmt.Println(stmtNodes[0], err)
 }

--- a/parser_example_test.go
+++ b/parser_example_test.go
@@ -16,7 +16,6 @@ package parser_test
 import (
 	"fmt"
 	"github.com/pingcap/parser"
-	// 0. import parser_driver implemented by TiDB(user also can implement own driver by self).
 	_ "github.com/pingcap/tidb/types/parser_driver"
 )
 
@@ -24,15 +23,15 @@ import (
 func Example_parseSQL() {
 
 	// 0. make sure import parser_driver implemented by TiDB(user also can implement own driver by self).
-	// import _ "github.com/pingcap/tidb/types/parser_driver" in import part.
+	// and add `import _ "github.com/pingcap/tidb/types/parser_driver"` in the head of file.
 
 	// 1. Create a parser, this is a NOT thread-safe but heavy object,
-	// it is better to reuse it in thread-safe way as possible  as we can.
+	// it is better to reuse it in thread-safe way as possible as we can.
 	p := parser.New()
 
 	// 2. Parse a text SQL into AST([]ast.StmtNode)
 	stmtNodes, err := p.Parse("select * from tbl where id = 1", "", "")
 
-	// 3. Use AST to do cool things~
+	// 3. Use AST to do cool thing~
 	fmt.Println(stmtNodes[0], err)
 }

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -76,6 +76,13 @@ type stmtTexter interface {
 
 // New returns a Parser object.
 func New() *Parser {
+	if ast.NewValueExpr == nil ||
+		ast.NewParamMarkerExpr == nil ||
+		ast.NewHexLiteral == nil ||
+		ast.NewBitLiteral == nil {
+		panic("no parser driver (forgotten import?) https://github.com/pingcap/parser/issues/43")
+	}
+
 	return &Parser{
 		cache: make([]yySymType, 200),
 	}


### PR DESCRIPTION
fixes #43

1. add driver import check when create parser, give better panic message.

2. add parser example, so [godoc](https://godoc.org/github/pingcap/parser) will have example just like this 
https://godoc.org/gopkg.in/lysu/parser.v1 after this PR merged

@tiancaiamao

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/parser/44)
<!-- Reviewable:end -->
