### PR TITLE
ast: implement the Restore function of UseStmt

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -341,7 +341,9 @@ type UseStmt struct {
 
 // Restore implements Recoverable interface.
 func (n *UseStmt) Restore(sb *strings.Builder) error {
-	return errors.New("Not implemented")
+	sb.WriteString("USE ")
+	WriteName(sb, n.DBName)
+	return nil
 }
 
 // Accept implements Node Accept interface.

--- a/parser_test.go
+++ b/parser_test.go
@@ -1403,8 +1403,9 @@ func (s *testParserSuite) TestIdentifier(c *C) {
 		// reserved keyword can't be used as identifier directly, but A.B pattern is an exception
 		{`select COUNT from DESC`, false, ""},
 		{`select COUNT from SELECT.DESC`, true, ""},
-		{"use `select`", true, ""},
-		{"use select", false, ""},
+		{"use `select`", true, "USE `select`"},
+		{"use `sel``ect`", true, "USE `sel``ect`"},
+		{"use select", false, "USE `select`"},
 		{`select * from t as a`, true, ""},
 		{"select 1 full, 1 row, 1 abs", false, ""},
 		{"select 1 full, 1 `row`, 1 abs", true, ""},


### PR DESCRIPTION
Firstly, we implement `Restore` function of `ast.UseStmt`.

Secondly, we add a test for `Restore`. For `ast.StmtNode`, we can test them in `parser_test.go` because they can restore to a complete SQL. We just need to add expect SQL to `testCase`, the `RunTest` function will help us to test it.

See: [RunTest Function](https://github.com/pingcap/parser/blob/ce4d755a8937ee6bc0e851fafdcd042ab5b1a1c1/parser_test.go#L255)

Issue: pingcap/tidb#8532