### PR TITLE
ast: impl Restore of ColunmNameExpr

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -371,7 +371,16 @@ type ColumnName struct {
 
 // Restore implements Recoverable interface.
 func (n *ColumnName) Restore(sb *strings.Builder) error {
-	return errors.New("Not implemented")
+	if n.Schema.L != "" {
+		WriteName(sb, n.Schema.L)
+		sb.WriteString(".")
+	}
+	if n.Table.L != "" {
+		WriteName(sb, n.Table.L)
+		sb.WriteString(".")
+	}
+	WriteName(sb, n.Name.L)
+	return nil
 }
 
 // Accept implements Node Accept interface.
@@ -424,7 +433,11 @@ type ColumnNameExpr struct {
 
 // Restore implements Recoverable interface.
 func (n *ColumnNameExpr) Restore(sb *strings.Builder) error {
-	return errors.New("Not implemented")
+	err := n.Name.Restore(sb)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // Format the ExprNode into a Writer.

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -371,15 +371,15 @@ type ColumnName struct {
 
 // Restore implements Recoverable interface.
 func (n *ColumnName) Restore(sb *strings.Builder) error {
-	if n.Schema.L != "" {
-		WriteName(sb, n.Schema.L)
+	if n.Schema.O != "" {
+		WriteName(sb, n.Schema.O)
 		sb.WriteString(".")
 	}
-	if n.Table.L != "" {
-		WriteName(sb, n.Table.L)
+	if n.Table.O != "" {
+		WriteName(sb, n.Table.O)
 		sb.WriteString(".")
 	}
-	WriteName(sb, n.Name.L)
+	WriteName(sb, n.Name.O)
 	return nil
 }
 

--- a/ast/expressions_test.go
+++ b/ast/expressions_test.go
@@ -119,6 +119,14 @@ func (tc *testExpressionsSuite) createTestCase4UnaryOperationExpr() []exprTestCa
 	}
 }
 
+func (tc *testExpressionsSuite) createTestCase4ColumnNameExpr() []exprTestCase {
+	return []exprTestCase{
+		{"select abc", "SELECT `abc`"},
+		{"select `abc`", "SELECT `abc`"},
+		{"select `ab``c`", "SELECT `ab``c`"},
+	}
+}
+
 func (tc *testExpressionsSuite) TestExpresionsRestore(c *C) {
 	parser := parser.New()
 	var testNodes []exprTestCase

--- a/ast/expressions_test.go
+++ b/ast/expressions_test.go
@@ -131,6 +131,7 @@ func (tc *testExpressionsSuite) TestExpresionsRestore(c *C) {
 	parser := parser.New()
 	var testNodes []exprTestCase
 	testNodes = append(testNodes, tc.createTestCase4UnaryOperationExpr()...)
+	testNodes = append(testNodes, tc.createTestCase4ColumnNameExpr()...)
 
 	for _, node := range testNodes {
 		stmt, err := parser.ParseOneStmt(node.sourceSQL, "", "")

--- a/ast/expressions_test.go
+++ b/ast/expressions_test.go
@@ -124,6 +124,10 @@ func (tc *testExpressionsSuite) createTestCase4ColumnNameExpr() []exprTestCase {
 		{"select abc", "SELECT `abc`"},
 		{"select `abc`", "SELECT `abc`"},
 		{"select `ab``c`", "SELECT `ab``c`"},
+		{"select sabc.tabc", "SELECT `sabc`.`tabc`"},
+		{"select dabc.sabc.tabc", "SELECT `dabc`.`sabc`.`tabc`"},
+		{"select dabc.`sabc`.tabc", "SELECT `dabc`.`sabc`.`tabc`"},
+		{"select `dabc`.`sabc`.tabc", "SELECT `dabc`.`sabc`.`tabc`"},
 	}
 }
 

--- a/ast/expressions_test.go
+++ b/ast/expressions_test.go
@@ -124,10 +124,10 @@ func (tc *testExpressionsSuite) createTestCase4ColumnNameExpr() []exprTestCase {
 		{"select abc", "SELECT `abc`"},
 		{"select `abc`", "SELECT `abc`"},
 		{"select `ab``c`", "SELECT `ab``c`"},
-		{"select sabc.tabc", "SELECT `sabc`.`tabc`"},
+		{"select sabc.tABC", "SELECT `sabc`.`tABC`"},
 		{"select dabc.sabc.tabc", "SELECT `dabc`.`sabc`.`tabc`"},
 		{"select dabc.`sabc`.tabc", "SELECT `dabc`.`sabc`.`tabc`"},
-		{"select `dabc`.`sabc`.tabc", "SELECT `dabc`.`sabc`.`tabc`"},
+		{"select `dABC`.`sabc`.tabc", "SELECT `dABC`.`sabc`.`tabc`"},
 	}
 }
 


### PR DESCRIPTION
Firstly, we implement `Restore` function of `ast.ColunmNameExpr` and `ast.ColunmName`.

Secondly, we add a test for `Restore`. In this case, `ast.ColunmNameExpr` can't restore to a complete SQL, so we can splice a sql to test it. We have already implemented a test function to simplify our work.

See: [TestExpresionsRestore Function](https://github.com/pingcap/parser/blob/ce4d755a8937ee6bc0e851fafdcd042ab5b1a1c1/ast/expressions_test.go#L122)

Issue: pingcap/tidb#8532