### PR TITLE
charset: make collation case insensitive

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -94,6 +94,7 @@ func ValidCharsetAndCollation(cs string, co string) bool {
 	if co == "" {
 		return true
 	}
+	co = strings.ToLower(co)
 	_, ok = c.Collations[co]
 	if !ok {
 		return false

--- a/charset/charset_test.go
+++ b/charset/charset_test.go
@@ -49,6 +49,12 @@ func (s *testCharsetSuite) TestValidCharset(c *C) {
 		{"utf8", "utf8_invalid_ci", false},
 		{"utf16", "utf16_bin", false},
 		{"gb2312", "gb2312_chinese_ci", false},
+		{"UTF8", "UTF8_BIN", true},
+		{"UTF8", "utf8_bin", true},
+		{"UTF8MB4", "utf8mb4_bin", true},
+		{"UTF8MB4", "UTF8MB4_bin", true},
+		{"UTF8MB4", "UTF8MB4_general_ci", true},
+		{"Utf8", "uTf8_bIN", true},
 	}
 	for _, tt := range tests {
 		testValidCharset(c, tt.cs, tt.co, tt.succ)


### PR DESCRIPTION
fix https://github.com/pingcap/tidb/issues/8304

before this PR, below case will failed.:

```
mysql> create table test(id int) ENGINE=InnoDB DEFAULT CHARSET=UTF8 COLLATE=UTF8_BIN;
ERROR 1115 (42000): Unknown character set: 'UTF8'
```