### PR TITLE
parser: add RestoreCtx and change the Node interface

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -17,7 +17,6 @@ package ast
 
 import (
 	"io"
-	"strings"
 
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/types"
@@ -27,7 +26,7 @@ import (
 // Interfaces embed Node should have 'Node' name suffix.
 type Node interface {
 	// Restore returns the sql text from ast tree
-	Restore(sb *strings.Builder) error
+	Restore(ctx *RestoreCtx) error
 	// Accept accepts Visitor to visit itself.
 	// The returned node should replace original node.
 	// ok returns false to stop visiting.

--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -67,10 +67,12 @@ type DatabaseOption struct {
 func (n *DatabaseOption) Restore(ctx *RestoreCtx) error {
 	switch n.Tp {
 	case DatabaseOptionCharset:
-		ctx.WriteKeyWord("CHARACTER SET = ")
+		ctx.WriteKeyWord("CHARACTER SET")
+		ctx.WritePlain(" = ")
 		ctx.WritePlain(n.Value)
 	case DatabaseOptionCollate:
-		ctx.WriteKeyWord("COLLATE = ")
+		ctx.WriteKeyWord("COLLATE")
+		ctx.WritePlain(" = ")
 		ctx.WritePlain(n.Value)
 	default:
 		return errors.Errorf("invalid DatabaseOptionType: %d", n.Tp)

--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -14,8 +14,6 @@
 package ast
 
 import (
-	"strings"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
@@ -65,15 +63,15 @@ type DatabaseOption struct {
 	Value string
 }
 
-// Restore implements Recoverable interface.
-func (n *DatabaseOption) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *DatabaseOption) Restore(ctx *RestoreCtx) error {
 	switch n.Tp {
 	case DatabaseOptionCharset:
-		sb.WriteString("CHARACTER SET = ")
-		sb.WriteString(n.Value)
+		ctx.WriteKeyWord("CHARACTER SET = ")
+		ctx.WritePlain(n.Value)
 	case DatabaseOptionCollate:
-		sb.WriteString("COLLATE = ")
-		sb.WriteString(n.Value)
+		ctx.WriteKeyWord("COLLATE = ")
+		ctx.WritePlain(n.Value)
 	default:
 		return errors.Errorf("invalid DatabaseOptionType: %d", n.Tp)
 	}
@@ -90,16 +88,16 @@ type CreateDatabaseStmt struct {
 	Options     []*DatabaseOption
 }
 
-// Restore implements Recoverable interface.
-func (n *CreateDatabaseStmt) Restore(sb *strings.Builder) error {
-	sb.WriteString("CREATE DATABASE ")
+// Restore implements Node interface.
+func (n *CreateDatabaseStmt) Restore(ctx *RestoreCtx) error {
+	ctx.WriteKeyWord("CREATE DATABASE ")
 	if n.IfNotExists {
-		sb.WriteString("IF NOT EXISTS ")
+		ctx.WriteKeyWord("IF NOT EXISTS ")
 	}
-	WriteName(sb, n.Name)
+	ctx.WriteName(n.Name)
 	for _, option := range n.Options {
-		sb.WriteString(" ")
-		err := option.Restore(sb)
+		ctx.WritePlain(" ")
+		err := option.Restore(ctx)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -126,13 +124,13 @@ type DropDatabaseStmt struct {
 	Name     string
 }
 
-// Restore implements Recoverable interface.
-func (n *DropDatabaseStmt) Restore(sb *strings.Builder) error {
-	sb.WriteString("DROP DATABASE ")
+// Restore implements Node interface.
+func (n *DropDatabaseStmt) Restore(ctx *RestoreCtx) error {
+	ctx.WriteKeyWord("DROP DATABASE ")
 	if n.IfExists {
-		sb.WriteString("IF EXISTS ")
+		ctx.WriteKeyWord("IF EXISTS ")
 	}
-	WriteName(sb, n.Name)
+	ctx.WriteName(n.Name)
 	return nil
 }
 
@@ -154,8 +152,8 @@ type IndexColName struct {
 	Length int
 }
 
-// Restore implements Recoverable interface.
-func (n *IndexColName) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *IndexColName) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -185,8 +183,8 @@ type ReferenceDef struct {
 	OnUpdate      *OnUpdateOpt
 }
 
-// Restore implements Recoverable interface.
-func (n *ReferenceDef) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ReferenceDef) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -255,8 +253,8 @@ type OnDeleteOpt struct {
 	ReferOpt ReferOptionType
 }
 
-// Restore implements Recoverable interface.
-func (n *OnDeleteOpt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *OnDeleteOpt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -276,8 +274,8 @@ type OnUpdateOpt struct {
 	ReferOpt ReferOptionType
 }
 
-// Restore implements Recoverable interface.
-func (n *OnUpdateOpt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *OnUpdateOpt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -325,8 +323,8 @@ type ColumnOption struct {
 	Refer *ReferenceDef
 }
 
-// Restore implements Recoverable interface.
-func (n *ColumnOption) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ColumnOption) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -361,8 +359,8 @@ type IndexOption struct {
 	Comment      string
 }
 
-// Restore implements Recoverable interface.
-func (n *IndexOption) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *IndexOption) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -406,8 +404,8 @@ type Constraint struct {
 	Option *IndexOption // Index Options
 }
 
-// Restore implements Recoverable interface.
-func (n *Constraint) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *Constraint) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -451,8 +449,8 @@ type ColumnDef struct {
 	Options []*ColumnOption
 }
 
-// Restore implements Recoverable interface.
-func (n *ColumnDef) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ColumnDef) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -494,8 +492,8 @@ type CreateTableStmt struct {
 	Select      ResultSetNode
 }
 
-// Restore implements Recoverable interface.
-func (n *CreateTableStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *CreateTableStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -553,8 +551,8 @@ type DropTableStmt struct {
 	IsView   bool
 }
 
-// Restore implements Recoverable interface.
-func (n *DropTableStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *DropTableStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -588,8 +586,8 @@ type RenameTableStmt struct {
 	TableToTables []*TableToTable
 }
 
-// Restore implements Recoverable interface.
-func (n *RenameTableStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *RenameTableStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -629,8 +627,8 @@ type TableToTable struct {
 	NewTable *TableName
 }
 
-// Restore implements Recoverable interface.
-func (n *TableToTable) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *TableToTable) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -669,8 +667,8 @@ type CreateViewStmt struct {
 	CheckOption model.ViewCheckOption
 }
 
-// Restore implements Recoverable interface.
-func (n *CreateViewStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *CreateViewStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -706,8 +704,8 @@ type CreateIndexStmt struct {
 	IndexOption   *IndexOption
 }
 
-// Restore implements Recoverable interface.
-func (n *CreateIndexStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *CreateIndexStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -750,8 +748,8 @@ type DropIndexStmt struct {
 	Table     *TableName
 }
 
-// Restore implements Recoverable interface.
-func (n *DropIndexStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *DropIndexStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -843,8 +841,8 @@ type ColumnPosition struct {
 	RelativeColumn *ColumnName
 }
 
-// Restore implements Recoverable interface.
-func (n *ColumnPosition) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ColumnPosition) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -925,8 +923,8 @@ type AlterTableSpec struct {
 	Num             uint64
 }
 
-// Restore implements Recoverable interface.
-func (n *AlterTableSpec) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *AlterTableSpec) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -984,8 +982,8 @@ type AlterTableStmt struct {
 	Specs []*AlterTableSpec
 }
 
-// Restore implements Recoverable interface.
-func (n *AlterTableStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *AlterTableStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -1019,8 +1017,8 @@ type TruncateTableStmt struct {
 	Table *TableName
 }
 
-// Restore implements Recoverable interface.
-func (n *TruncateTableStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *TruncateTableStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 

--- a/ast/dml.go
+++ b/ast/dml.go
@@ -14,8 +14,6 @@
 package ast
 
 import (
-	"strings"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
@@ -85,8 +83,8 @@ type Join struct {
 	StraightJoin bool
 }
 
-// Restore implements Recoverable interface.
-func (n *Join) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *Join) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -133,16 +131,16 @@ type TableName struct {
 	IndexHints []*IndexHint
 }
 
-// Restore implements Recoverable interface.
-func (n *TableName) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *TableName) Restore(ctx *RestoreCtx) error {
 	if n.Schema.String() != "" {
-		WriteName(sb, n.Schema.String())
-		sb.WriteString(".")
+		ctx.WriteName(n.Schema.String())
+		ctx.WritePlain(".")
 	}
-	WriteName(sb, n.Name.String())
+	ctx.WriteName(n.Name.String())
 	for _, value := range n.IndexHints {
-		sb.WriteString(" ")
-		if err := value.Restore(sb); err != nil {
+		ctx.WritePlain(" ")
+		if err := value.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while splicing IndexHints")
 		}
 	}
@@ -178,7 +176,7 @@ type IndexHint struct {
 }
 
 // IndexHint Restore (The const field uses switch to facilitate understanding)
-func (n *IndexHint) Restore(sb *strings.Builder) error {
+func (n *IndexHint) Restore(ctx *RestoreCtx) error {
 	indexHintType := ""
 	switch n.HintType {
 	case 1:
@@ -204,17 +202,16 @@ func (n *IndexHint) Restore(sb *strings.Builder) error {
 	default: // Prevent accidents
 		return errors.New("IndexHintScope has an error while matching")
 	}
-
-	sb.WriteString(indexHintType)
-	sb.WriteString(indexHintScope)
-	sb.WriteString(" (")
+	ctx.WriteKeyWord(indexHintType)
+	ctx.WriteKeyWord(indexHintScope)
+	ctx.WritePlain(" (")
 	for i, value := range n.IndexNames {
 		if i > 0 {
-			sb.WriteString(", ")
+			ctx.WritePlain(", ")
 		}
-		WriteName(sb, value.O)
+		ctx.WriteName(value.O)
 	}
-	sb.WriteString(")")
+	ctx.WritePlain(")")
 
 	return nil
 }
@@ -235,8 +232,8 @@ type DeleteTableList struct {
 	Tables []*TableName
 }
 
-// Restore implements Recoverable interface.
-func (n *DeleteTableList) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *DeleteTableList) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -266,8 +263,8 @@ type OnCondition struct {
 	Expr ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *OnCondition) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *OnCondition) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -298,8 +295,8 @@ type TableSource struct {
 	AsName model.CIStr
 }
 
-// Restore implements Recoverable interface.
-func (n *TableSource) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *TableSource) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -349,8 +346,8 @@ type WildCardField struct {
 	Schema model.CIStr
 }
 
-// Restore implements Recoverable interface.
-func (n *WildCardField) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *WildCardField) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -384,8 +381,8 @@ type SelectField struct {
 	Auxiliary bool
 }
 
-// Restore implements Recoverable interface.
-func (n *SelectField) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *SelectField) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -413,8 +410,8 @@ type FieldList struct {
 	Fields []*SelectField
 }
 
-// Restore implements Recoverable interface.
-func (n *FieldList) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *FieldList) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -442,8 +439,8 @@ type TableRefsClause struct {
 	TableRefs *Join
 }
 
-// Restore implements Recoverable interface.
-func (n *TableRefsClause) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *TableRefsClause) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -470,8 +467,8 @@ type ByItem struct {
 	Desc bool
 }
 
-// Restore implements Recoverable interface.
-func (n *ByItem) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ByItem) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -496,8 +493,8 @@ type GroupByClause struct {
 	Items []*ByItem
 }
 
-// Restore implements Recoverable interface.
-func (n *GroupByClause) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *GroupByClause) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -524,8 +521,8 @@ type HavingClause struct {
 	Expr ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *HavingClause) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *HavingClause) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -551,8 +548,8 @@ type OrderByClause struct {
 	ForUnion bool
 }
 
-// Restore implements Recoverable interface.
-func (n *OrderByClause) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *OrderByClause) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -609,8 +606,8 @@ type SelectStmt struct {
 	IsInBraces bool
 }
 
-// Restore implements Recoverable interface.
-func (n *SelectStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *SelectStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -708,8 +705,8 @@ type UnionSelectList struct {
 	Selects []*SelectStmt
 }
 
-// Restore implements Recoverable interface.
-func (n *UnionSelectList) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *UnionSelectList) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -741,8 +738,8 @@ type UnionStmt struct {
 	Limit      *Limit
 }
 
-// Restore implements Recoverable interface.
-func (n *UnionStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *UnionStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -786,8 +783,8 @@ type Assignment struct {
 	Expr ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *Assignment) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *Assignment) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -825,8 +822,8 @@ type LoadDataStmt struct {
 	IgnoreLines uint64
 }
 
-// Restore implements Recoverable interface.
-func (n *LoadDataStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *LoadDataStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -883,8 +880,8 @@ type InsertStmt struct {
 	Select      ResultSetNode
 }
 
-// Restore implements Recoverable interface.
-func (n *InsertStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *InsertStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -964,8 +961,8 @@ type DeleteStmt struct {
 	TableHints []*TableOptimizerHint
 }
 
-// Restore implements Recoverable interface.
-func (n *DeleteStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *DeleteStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -1029,8 +1026,8 @@ type UpdateStmt struct {
 	TableHints    []*TableOptimizerHint
 }
 
-// Restore implements Recoverable interface.
-func (n *UpdateStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *UpdateStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -1085,8 +1082,8 @@ type Limit struct {
 	Offset ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *Limit) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *Limit) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -1170,8 +1167,8 @@ type ShowStmt struct {
 	Where       ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *ShowStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ShowStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -1235,8 +1232,8 @@ type WindowSpec struct {
 	Frame       *FrameClause
 }
 
-// Restore implements Recoverable interface.
-func (n *WindowSpec) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *WindowSpec) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -1278,8 +1275,8 @@ type PartitionByClause struct {
 	Items []*ByItem
 }
 
-// Restore implements Recoverable interface.
-func (n *PartitionByClause) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *PartitionByClause) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -1319,8 +1316,8 @@ type FrameClause struct {
 	Extent FrameExtent
 }
 
-// Restore implements Recoverable interface.
-func (n *FrameClause) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *FrameClause) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -1372,8 +1369,8 @@ type FrameBound struct {
 	Unit ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *FrameBound) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *FrameBound) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -79,8 +79,8 @@ type BetweenExpr struct {
 	Not bool
 }
 
-// Restore implements Recoverable interface.
-func (n *BetweenExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *BetweenExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -137,8 +137,8 @@ type BinaryOperationExpr struct {
 	R ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *BinaryOperationExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *BinaryOperationExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -183,8 +183,8 @@ type WhenClause struct {
 	Result ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *WhenClause) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *WhenClause) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -221,8 +221,8 @@ type CaseExpr struct {
 	ElseClause ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *CaseExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *CaseExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -290,8 +290,8 @@ type SubqueryExpr struct {
 	Exists     bool
 }
 
-// Restore implements Recoverable interface.
-func (n *SubqueryExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *SubqueryExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -331,8 +331,8 @@ type CompareSubqueryExpr struct {
 	All bool
 }
 
-// Restore implements Recoverable interface.
-func (n *CompareSubqueryExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *CompareSubqueryExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -369,17 +369,17 @@ type ColumnName struct {
 	Name   model.CIStr
 }
 
-// Restore implements Recoverable interface.
-func (n *ColumnName) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ColumnName) Restore(ctx *RestoreCtx) error {
 	if n.Schema.O != "" {
-		WriteName(sb, n.Schema.O)
-		sb.WriteString(".")
+		ctx.WriteName(n.Schema.O)
+		ctx.WritePlain(".")
 	}
 	if n.Table.O != "" {
-		WriteName(sb, n.Table.O)
-		sb.WriteString(".")
+		ctx.WriteName(n.Table.O)
+		ctx.WritePlain(".")
 	}
-	WriteName(sb, n.Name.O)
+	ctx.WriteName(n.Name.O)
 	return nil
 }
 
@@ -431,9 +431,9 @@ type ColumnNameExpr struct {
 	Refer *ResultField
 }
 
-// Restore implements Recoverable interface.
-func (n *ColumnNameExpr) Restore(sb *strings.Builder) error {
-	err := n.Name.Restore(sb)
+// Restore implements Node interface.
+func (n *ColumnNameExpr) Restore(ctx *RestoreCtx) error {
+	err := n.Name.Restore(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -468,8 +468,8 @@ type DefaultExpr struct {
 	Name *ColumnName
 }
 
-// Restore implements Recoverable interface.
-func (n *DefaultExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *DefaultExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -505,8 +505,8 @@ type ExistsSubqueryExpr struct {
 	Not bool
 }
 
-// Restore implements Recoverable interface.
-func (n *ExistsSubqueryExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ExistsSubqueryExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -543,8 +543,8 @@ type PatternInExpr struct {
 	Sel ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *PatternInExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *PatternInExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -603,9 +603,9 @@ type IsNullExpr struct {
 	Not bool
 }
 
-// Restore implements Recoverable interface.
-func (n *IsNullExpr) Restore(sb *strings.Builder) error {
-	n.Format(sb)
+// Restore implements Node interface.
+func (n *IsNullExpr) Restore(ctx *RestoreCtx) error {
+	n.Format(ctx.In)
 	return nil
 }
 
@@ -645,8 +645,8 @@ type IsTruthExpr struct {
 	True int64
 }
 
-// Restore implements Recoverable interface.
-func (n *IsTruthExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *IsTruthExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -696,8 +696,8 @@ type PatternLikeExpr struct {
 	PatTypes []byte
 }
 
-// Restore implements Recoverable interface.
-func (n *PatternLikeExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *PatternLikeExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -754,8 +754,8 @@ type ParenthesesExpr struct {
 	Expr ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *ParenthesesExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ParenthesesExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -796,8 +796,8 @@ type PositionExpr struct {
 	Refer *ResultField
 }
 
-// Restore implements Recoverable interface.
-func (n *PositionExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *PositionExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -839,8 +839,8 @@ type PatternRegexpExpr struct {
 	Sexpr *string
 }
 
-// Restore implements Recoverable interface.
-func (n *PatternRegexpExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *PatternRegexpExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -883,8 +883,8 @@ type RowExpr struct {
 	Values []ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *RowExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *RowExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -919,9 +919,9 @@ type UnaryOperationExpr struct {
 	V ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *UnaryOperationExpr) Restore(sb *strings.Builder) error {
-	n.Format(sb)
+// Restore implements Node interface.
+func (n *UnaryOperationExpr) Restore(ctx *RestoreCtx) error {
+	n.Format(ctx.In)
 	return nil
 }
 
@@ -953,8 +953,8 @@ type ValuesExpr struct {
 	Column *ColumnNameExpr
 }
 
-// Restore implements Recoverable interface.
-func (n *ValuesExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ValuesExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -995,8 +995,8 @@ type VariableExpr struct {
 	Value ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *VariableExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *VariableExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -1029,8 +1029,8 @@ type MaxValueExpr struct {
 	exprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *MaxValueExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *MaxValueExpr) Restore(ctx *RestoreCtx) error {
 	panic("Not implemented")
 }
 

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -433,8 +433,7 @@ type ColumnNameExpr struct {
 
 // Restore implements Node interface.
 func (n *ColumnNameExpr) Restore(ctx *RestoreCtx) error {
-	err := n.Name.Restore(ctx)
-	if err != nil {
+	if err := n.Name.Restore(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -605,7 +604,14 @@ type IsNullExpr struct {
 
 // Restore implements Node interface.
 func (n *IsNullExpr) Restore(ctx *RestoreCtx) error {
-	n.Format(ctx.In)
+	if err := n.Expr.Restore(ctx); err != nil {
+		return errors.Trace(err)
+	}
+	if n.Not {
+		ctx.WriteKeyWord(" IS NOT NULL")
+	} else {
+		ctx.WriteKeyWord(" IS NULL")
+	}
 	return nil
 }
 
@@ -921,7 +927,12 @@ type UnaryOperationExpr struct {
 
 // Restore implements Node interface.
 func (n *UnaryOperationExpr) Restore(ctx *RestoreCtx) error {
-	n.Format(ctx.In)
+	if err := n.Op.Restore(ctx.In); err != nil {
+		return errors.Trace(err)
+	}
+	if err := n.V.Restore(ctx); err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }
 

--- a/ast/functions.go
+++ b/ast/functions.go
@@ -16,7 +16,6 @@ package ast
 import (
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
@@ -329,8 +328,8 @@ type FuncCallExpr struct {
 	Args []ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *FuncCallExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *FuncCallExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -406,8 +405,8 @@ type FuncCastExpr struct {
 	FunctionType CastFunctionType
 }
 
-// Restore implements Recoverable interface.
-func (n *FuncCastExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *FuncCastExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -519,8 +518,8 @@ type AggregateFuncExpr struct {
 	Distinct bool
 }
 
-// Restore implements Recoverable interface.
-func (n *AggregateFuncExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *AggregateFuncExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -592,8 +591,8 @@ type WindowFuncExpr struct {
 	Spec WindowSpec
 }
 
-// Restore implements Recoverable interface.
-func (n *WindowFuncExpr) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *WindowFuncExpr) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 

--- a/ast/misc.go
+++ b/ast/misc.go
@@ -98,8 +98,8 @@ type TraceStmt struct {
 	Format string
 }
 
-// Restore implements Recoverable interface.
-func (n *TraceStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *TraceStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -129,8 +129,8 @@ type ExplainStmt struct {
 	Analyze bool
 }
 
-// Restore implements Recoverable interface.
-func (n *ExplainStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ExplainStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -160,8 +160,8 @@ type PrepareStmt struct {
 	SQLVar  *VariableExpr
 }
 
-// Restore implements Recoverable interface.
-func (n *PrepareStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *PrepareStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -190,8 +190,8 @@ type DeallocateStmt struct {
 	Name string
 }
 
-// Restore implements Recoverable interface.
-func (n *DeallocateStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *DeallocateStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -223,8 +223,8 @@ type ExecuteStmt struct {
 	ExecID    uint32
 }
 
-// Restore implements Recoverable interface.
-func (n *ExecuteStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *ExecuteStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -251,8 +251,8 @@ type BeginStmt struct {
 	stmtNode
 }
 
-// Restore implements Recoverable interface.
-func (n *BeginStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *BeginStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -274,8 +274,8 @@ type BinlogStmt struct {
 	Str string
 }
 
-// Restore implements Recoverable interface.
-func (n *BinlogStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *BinlogStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -295,8 +295,8 @@ type CommitStmt struct {
 	stmtNode
 }
 
-// Restore implements Recoverable interface.
-func (n *CommitStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *CommitStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -316,8 +316,8 @@ type RollbackStmt struct {
 	stmtNode
 }
 
-// Restore implements Recoverable interface.
-func (n *RollbackStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *RollbackStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -339,10 +339,10 @@ type UseStmt struct {
 	DBName string
 }
 
-// Restore implements Recoverable interface.
-func (n *UseStmt) Restore(sb *strings.Builder) error {
-	sb.WriteString("USE ")
-	WriteName(sb, n.DBName)
+// Restore implements Node interface.
+func (n *UseStmt) Restore(ctx *RestoreCtx) error {
+	ctx.WriteKeyWord("USE ")
+	ctx.WriteName(n.DBName)
 	return nil
 }
 
@@ -377,8 +377,8 @@ type VariableAssignment struct {
 	ExtendValue ValueExpr
 }
 
-// Restore implements Recoverable interface.
-func (n *VariableAssignment) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *VariableAssignment) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -418,8 +418,8 @@ type FlushStmt struct {
 	ReadLock        bool
 }
 
-// Restore implements Recoverable interface.
-func (n *FlushStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *FlushStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -453,8 +453,8 @@ type KillStmt struct {
 	TiDBExtension bool
 }
 
-// Restore implements Recoverable interface.
-func (n *KillStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *KillStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -475,8 +475,8 @@ type SetStmt struct {
 	Variables []*VariableAssignment
 }
 
-// Restore implements Recoverable interface.
-func (n *SetStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *SetStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -527,8 +527,8 @@ type SetPwdStmt struct {
 	Password string
 }
 
-// Restore implements Recoverable interface.
-func (n *SetPwdStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *SetPwdStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -595,8 +595,8 @@ type CreateUserStmt struct {
 	Specs       []*UserSpec
 }
 
-// Restore implements Recoverable interface.
-func (n *CreateUserStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *CreateUserStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -631,8 +631,8 @@ type AlterUserStmt struct {
 	Specs       []*UserSpec
 }
 
-// Restore implements Recoverable interface.
-func (n *AlterUserStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *AlterUserStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -666,8 +666,8 @@ type DropUserStmt struct {
 	UserList []*auth.UserIdentity
 }
 
-// Restore implements Recoverable interface.
-func (n *DropUserStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *DropUserStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -688,8 +688,8 @@ type DoStmt struct {
 	Exprs []ExprNode
 }
 
-// Restore implements Recoverable interface.
-func (n *DoStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *DoStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -780,8 +780,8 @@ type AdminStmt struct {
 	ShowSlow     *ShowSlow
 }
 
-// Restore implements Recoverable interface.
-func (n *AdminStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *AdminStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -812,8 +812,8 @@ type PrivElem struct {
 	Cols []*ColumnName
 }
 
-// Restore implements Recoverable interface.
-func (n *PrivElem) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *PrivElem) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -875,8 +875,8 @@ type RevokeStmt struct {
 	Users      []*UserSpec
 }
 
-// Restore implements Recoverable interface.
-func (n *RevokeStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *RevokeStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -908,8 +908,8 @@ type GrantStmt struct {
 	WithGrant  bool
 }
 
-// Restore implements Recoverable interface.
-func (n *GrantStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *GrantStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -978,8 +978,8 @@ type TableOptimizerHint struct {
 	MaxExecutionTime uint64
 }
 
-// Restore implements Recoverable interface.
-func (n *TableOptimizerHint) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *TableOptimizerHint) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 

--- a/ast/stats.go
+++ b/ast/stats.go
@@ -14,8 +14,6 @@
 package ast
 
 import (
-	"strings"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 )
@@ -39,8 +37,8 @@ type AnalyzeTableStmt struct {
 	IndexFlag bool
 }
 
-// Restore implements Recoverable interface.
-func (n *AnalyzeTableStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *AnalyzeTableStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -68,8 +66,8 @@ type DropStatsStmt struct {
 	Table *TableName
 }
 
-// Restore implements Recoverable interface.
-func (n *DropStatsStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *DropStatsStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 
@@ -95,8 +93,8 @@ type LoadStatsStmt struct {
 	Path string
 }
 
-// Restore implements Recoverable interface.
-func (n *LoadStatsStmt) Restore(sb *strings.Builder) error {
+// Restore implements Node interface.
+func (n *LoadStatsStmt) Restore(ctx *RestoreCtx) error {
 	return errors.New("Not implemented")
 }
 

--- a/ast/util.go
+++ b/ast/util.go
@@ -102,42 +102,42 @@ func (rf RestoreFlags) HasStringSingleQuotesFlag() bool {
 	return rf.has(RestoreStringSingleQuotes)
 }
 
-// HasStringDoubleQuotesFlag returns a boolean indicating weather `rf` has `RestoreStringDoubleQuotes` flag.
+// HasStringDoubleQuotesFlag returns a boolean indicating whether `rf` has `RestoreStringDoubleQuotes` flag.
 func (rf RestoreFlags) HasStringDoubleQuotesFlag() bool {
 	return rf.has(RestoreStringDoubleQuotes)
 }
 
-// HasStringEscapeBackslashFlag returns a boolean indicating weather `rf` has `RestoreStringEscapeBackslash` flag.
+// HasStringEscapeBackslashFlag returns a boolean indicating whether `rf` has `RestoreStringEscapeBackslash` flag.
 func (rf RestoreFlags) HasStringEscapeBackslashFlag() bool {
 	return rf.has(RestoreStringEscapeBackslash)
 }
 
-// HasKeyWordUppercaseFlag returns a boolean indicating weather `rf` has `RestoreKeyWordUppercase` flag.
+// HasKeyWordUppercaseFlag returns a boolean indicating whether `rf` has `RestoreKeyWordUppercase` flag.
 func (rf RestoreFlags) HasKeyWordUppercaseFlag() bool {
 	return rf.has(RestoreKeyWordUppercase)
 }
 
-// HasKeyWordLowercaseFlag returns a boolean indicating weather `rf` has `RestoreKeyWordLowercase` flag.
+// HasKeyWordLowercaseFlag returns a boolean indicating whether `rf` has `RestoreKeyWordLowercase` flag.
 func (rf RestoreFlags) HasKeyWordLowercaseFlag() bool {
 	return rf.has(RestoreKeyWordLowercase)
 }
 
-// HasNameUppercaseFlag returns a boolean indicating weather `rf` has `RestoreNameUppercase` flag.
+// HasNameUppercaseFlag returns a boolean indicating whether `rf` has `RestoreNameUppercase` flag.
 func (rf RestoreFlags) HasNameUppercaseFlag() bool {
 	return rf.has(RestoreNameUppercase)
 }
 
-// HasNameLowercaseFlag returns a boolean indicating weather `rf` has `RestoreNameLowercase` flag.
+// HasNameLowercaseFlag returns a boolean indicating whether `rf` has `RestoreNameLowercase` flag.
 func (rf RestoreFlags) HasNameLowercaseFlag() bool {
 	return rf.has(RestoreNameLowercase)
 }
 
-// HasNameDoubleQuotesFlag returns a boolean indicating weather `rf` has `RestoreNameDoubleQuotes` flag.
+// HasNameDoubleQuotesFlag returns a boolean indicating whether `rf` has `RestoreNameDoubleQuotes` flag.
 func (rf RestoreFlags) HasNameDoubleQuotesFlag() bool {
 	return rf.has(RestoreNameDoubleQuotes)
 }
 
-// HasNameBackQuotesFlag returns a boolean indicating weather `rf` has `RestoreNameBackQuotes` flag.
+// HasNameBackQuotesFlag returns a boolean indicating whether `rf` has `RestoreNameBackQuotes` flag.
 func (rf RestoreFlags) HasNameBackQuotesFlag() bool {
 	return rf.has(RestoreNameBackQuotes)
 }

--- a/ast/util.go
+++ b/ast/util.go
@@ -115,7 +115,7 @@ func (ctx *RestoreCtx) WriteKeyWord(keyWord string) {
 	case ctx.Flags.Has(RestoreKeyWordLowercase):
 		keyWord = strings.ToLower(keyWord)
 	}
-	_, _ = fmt.Fprint(ctx.In, keyWord)
+	fmt.Fprint(ctx.In, keyWord)
 }
 
 // WriteKeyWord write the string into writer
@@ -130,7 +130,7 @@ func (ctx *RestoreCtx) WriteString(str string) {
 	case ctx.Flags.Has(RestoreStringDoubleQuotes):
 		quotes = "\""
 	}
-	_, _ = fmt.Fprint(ctx.In, quotes, str, quotes)
+	fmt.Fprint(ctx.In, quotes, str, quotes)
 }
 
 // WriteName write the name into writer
@@ -153,10 +153,10 @@ func (ctx *RestoreCtx) WriteName(name string) {
 	case ctx.Flags.Has(RestoreNameBackQuote):
 		quotes = "`"
 	}
-	_, _ = fmt.Fprint(ctx.In, quotes, name, quotes)
+	fmt.Fprint(ctx.In, quotes, name, quotes)
 }
 
 // WriteName write the plain text into writer without any handling
 func (ctx *RestoreCtx) WritePlain(plainText string) {
-	_, _ = fmt.Fprint(ctx.In, plainText)
+	fmt.Fprint(ctx.In, plainText)
 }

--- a/ast/util.go
+++ b/ast/util.go
@@ -80,15 +80,13 @@ const (
 	RestoreNameUppercase
 	RestoreNameLowercase
 	RestoreNameOriginal
-	RestoreNameSingleQuotes
 	RestoreNameDoubleQuotes
 	RestoreNameBackQuote
-	RestoreNameEscapeBackQuote
 )
 
 const (
 	DefaultRestoreFlags = RestoreStringSingleQuotes | RestoreKeyWordUppercase | RestoreNameOriginal |
-		RestoreNameBackQuote | RestoreNameEscapeBackQuote
+		RestoreNameBackQuote
 )
 
 // Has return weather `rf` has this flag
@@ -108,6 +106,7 @@ func NewRestoreCtx(flags RestoreFlags, in io.Writer) *RestoreCtx {
 }
 
 // WriteKeyWord write the keyword into writer
+// keyWord will be converted format(uppercase and lowercase for now) according to RestoreFlags
 func (ctx *RestoreCtx) WriteKeyWord(keyWord string) {
 	switch {
 	case ctx.Flags.Has(RestoreKeyWordUppercase):
@@ -118,26 +117,27 @@ func (ctx *RestoreCtx) WriteKeyWord(keyWord string) {
 	fmt.Fprint(ctx.In, keyWord)
 }
 
-// WriteKeyWord write the string into writer
+// WriteString write the string into writer
+// str maybe wrapped in quotes and escape according to RestoreFlags
 func (ctx *RestoreCtx) WriteString(str string) {
 	if ctx.Flags.Has(RestoreStringEscapeBackslash) {
-		str = strings.Replace(str, "\\", "\\\\", -1)
+		str = strings.Replace(str, `\`, `\\`, -1)
 	}
 	quotes := ""
 	switch {
 	case ctx.Flags.Has(RestoreStringSingleQuotes):
-		quotes = "'"
+		str = strings.Replace(str, `'`, `''`, -1)
+		quotes = `''`
 	case ctx.Flags.Has(RestoreStringDoubleQuotes):
-		quotes = "\""
+		str = strings.Replace(str, `"`, `""`, -1)
+		quotes = `"`
 	}
 	fmt.Fprint(ctx.In, quotes, str, quotes)
 }
 
 // WriteName write the name into writer
+// name maybe wrapped in quotes and escape according to RestoreFlags
 func (ctx *RestoreCtx) WriteName(name string) {
-	if ctx.Flags.Has(RestoreNameEscapeBackQuote) {
-		name = strings.Replace(name, "`", "``", -1)
-	}
 	switch {
 	case ctx.Flags.Has(RestoreNameUppercase):
 		name = strings.ToUpper(name)
@@ -146,11 +146,11 @@ func (ctx *RestoreCtx) WriteName(name string) {
 	}
 	quotes := ""
 	switch {
-	case ctx.Flags.Has(RestoreNameSingleQuotes):
-		quotes = "'"
 	case ctx.Flags.Has(RestoreNameDoubleQuotes):
-		quotes = "\""
+		name = strings.Replace(name, `"`, `""`, -1)
+		quotes = `"`
 	case ctx.Flags.Has(RestoreNameBackQuote):
+		name = strings.Replace(name, "`", "``", -1)
 		quotes = "`"
 	}
 	fmt.Fprint(ctx.In, quotes, name, quotes)

--- a/ast/util.go
+++ b/ast/util.go
@@ -127,7 +127,7 @@ func (ctx *RestoreCtx) WriteString(str string) {
 	switch {
 	case ctx.Flags.Has(RestoreStringSingleQuotes):
 		str = strings.Replace(str, `'`, `''`, -1)
-		quotes = `''`
+		quotes = `'`
 	case ctx.Flags.Has(RestoreStringDoubleQuotes):
 		str = strings.Replace(str, `"`, `""`, -1)
 		quotes = `"`

--- a/ast/util.go
+++ b/ast/util.go
@@ -93,54 +93,53 @@ const (
 	DefaultRestoreFlags = RestoreStringSingleQuotes | RestoreKeyWordUppercase | RestoreNameBackQuotes
 )
 
-// Has returns weather `rf` has this `flag`.
-func (rf RestoreFlags) Has(flag RestoreFlags) bool {
+func (rf RestoreFlags) has(flag RestoreFlags) bool {
 	return rf&flag != 0
 }
 
-// HasStringSingleQuotesFlag returns weather `rf` has `RestoreStringSingleQuotes` flag.
+// HasStringSingleQuotesFlag returns a boolean indicating when `rf` has `RestoreStringSingleQuotes` flag.
 func (rf RestoreFlags) HasStringSingleQuotesFlag() bool {
-	return rf.Has(RestoreStringSingleQuotes)
+	return rf.has(RestoreStringSingleQuotes)
 }
 
-// HasStringDoubleQuotesFlag returns weather `rf` has `RestoreStringDoubleQuotes` flag.
+// HasStringDoubleQuotesFlag returns a boolean indicating weather `rf` has `RestoreStringDoubleQuotes` flag.
 func (rf RestoreFlags) HasStringDoubleQuotesFlag() bool {
-	return rf.Has(RestoreStringDoubleQuotes)
+	return rf.has(RestoreStringDoubleQuotes)
 }
 
-// HasStringEscapeBackslashFlag returns weather `rf` has `RestoreStringEscapeBackslash` flag.
+// HasStringEscapeBackslashFlag returns a boolean indicating weather `rf` has `RestoreStringEscapeBackslash` flag.
 func (rf RestoreFlags) HasStringEscapeBackslashFlag() bool {
-	return rf.Has(RestoreStringEscapeBackslash)
+	return rf.has(RestoreStringEscapeBackslash)
 }
 
-// HasKeyWordUppercaseFlag returns weather `rf` has `RestoreKeyWordUppercase` flag.
+// HasKeyWordUppercaseFlag returns a boolean indicating weather `rf` has `RestoreKeyWordUppercase` flag.
 func (rf RestoreFlags) HasKeyWordUppercaseFlag() bool {
-	return rf.Has(RestoreKeyWordUppercase)
+	return rf.has(RestoreKeyWordUppercase)
 }
 
-// HasKeyWordLowercaseFlag returns weather `rf` has `RestoreKeyWordLowercase` flag.
+// HasKeyWordLowercaseFlag returns a boolean indicating weather `rf` has `RestoreKeyWordLowercase` flag.
 func (rf RestoreFlags) HasKeyWordLowercaseFlag() bool {
-	return rf.Has(RestoreKeyWordLowercase)
+	return rf.has(RestoreKeyWordLowercase)
 }
 
-// HasNameUppercaseFlag returns weather `rf` has `RestoreNameUppercase` flag.
+// HasNameUppercaseFlag returns a boolean indicating weather `rf` has `RestoreNameUppercase` flag.
 func (rf RestoreFlags) HasNameUppercaseFlag() bool {
-	return rf.Has(RestoreNameUppercase)
+	return rf.has(RestoreNameUppercase)
 }
 
-// HasNameLowercaseFlag returns weather `rf` has `RestoreNameLowercase` flag.
+// HasNameLowercaseFlag returns a boolean indicating weather `rf` has `RestoreNameLowercase` flag.
 func (rf RestoreFlags) HasNameLowercaseFlag() bool {
-	return rf.Has(RestoreNameLowercase)
+	return rf.has(RestoreNameLowercase)
 }
 
-// HasNameDoubleQuotesFlag returns weather `rf` has `RestoreNameDoubleQuotes` flag.
+// HasNameDoubleQuotesFlag returns a boolean indicating weather `rf` has `RestoreNameDoubleQuotes` flag.
 func (rf RestoreFlags) HasNameDoubleQuotesFlag() bool {
-	return rf.Has(RestoreNameDoubleQuotes)
+	return rf.has(RestoreNameDoubleQuotes)
 }
 
-// HasNameBackQuotesFlag returns weather `rf` has `RestoreNameBackQuotes` flag.
+// HasNameBackQuotesFlag returns a boolean indicating weather `rf` has `RestoreNameBackQuotes` flag.
 func (rf RestoreFlags) HasNameBackQuotesFlag() bool {
-	return rf.Has(RestoreNameBackQuotes)
+	return rf.has(RestoreNameBackQuotes)
 }
 
 // RestoreCtx is `Restore` context to hold flags and writer.

--- a/ast/util.go
+++ b/ast/util.go
@@ -156,7 +156,12 @@ func (ctx *RestoreCtx) WriteName(name string) {
 	fmt.Fprint(ctx.In, quotes, name, quotes)
 }
 
-// WriteName write the plain text into writer without any handling
+// WritePlain write the plain text into writer without any handling
 func (ctx *RestoreCtx) WritePlain(plainText string) {
 	fmt.Fprint(ctx.In, plainText)
+}
+
+// WritePlainf write the plain text into writer without any handling
+func (ctx *RestoreCtx) WritePlainf(format string, a ...interface{}) {
+	fmt.Fprintf(ctx.In, format, a...)
 }

--- a/ast/util_test.go
+++ b/ast/util_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 var _ = Suite(&testCacheableSuite{})
+var _ = Suite(&testRestoreCtxSuite{})
 
 type testCacheableSuite struct {
 }

--- a/ast/util_test.go
+++ b/ast/util_test.go
@@ -71,6 +71,35 @@ func (checker *nodeTextCleaner) Leave(in Node) (out Node, ok bool) {
 	return in, true
 }
 
+type testRestoreCtxSuite struct {
+}
+
+func (s *testRestoreCtxSuite) TestRestoreCtx(c *C) {
+	var sb strings.Builder
+	ctx := NewRestoreCtx(DefaultRestoreFlags, &sb)
+	ctx.WriteKeyWord("SELECT")
+	ctx.WritePlain(" * ")
+	ctx.WriteKeyWord("FROM ")
+	ctx.WriteName("tabl`e1")
+	ctx.WriteKeyWord(" WHERE ")
+	ctx.WriteName("col1")
+	ctx.WritePlain(" = ")
+	ctx.WriteString("abc")
+	c.Assert(sb.String(), Equals, "SELECT * FROM `tabl``e1` WHERE `col1` = 'abc'")
+	sb.Reset()
+	ctx = NewRestoreCtx(RestoreStringDoubleQuotes|RestoreKeyWordLowercase|RestoreNameUppercase|
+		RestoreStringEscapeBackslash, &sb)
+	ctx.WriteKeyWord("SELECT")
+	ctx.WritePlain(" * ")
+	ctx.WriteKeyWord("FROM ")
+	ctx.WriteName("table1")
+	ctx.WriteKeyWord(" WHERE ")
+	ctx.WriteName("col1")
+	ctx.WritePlain(" = ")
+	ctx.WriteString(`ab\c`)
+	c.Assert(sb.String(), Equals, `select * from TABLE1 where COL1 = "ab\\c"`)
+}
+
 type NodeRestoreTestCase struct {
 	sourceSQL string
 	expectSQL string

--- a/ast/util_test.go
+++ b/ast/util_test.go
@@ -48,21 +48,6 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 	c.Assert(IsReadOnly(stmt), IsTrue)
 }
 
-func (s *testCacheableSuite) TestWriteName(c *C) {
-	var sb strings.Builder
-	WriteName(&sb, "")
-	sb.WriteString(";")
-	WriteName(&sb, "abc")
-	sb.WriteString(";")
-	WriteName(&sb, "ab`c")
-	sb.WriteString(";")
-	WriteName(&sb, "ab``c")
-	sb.WriteString(";")
-	WriteName(&sb, "ab` `c")
-	sb.WriteString(";")
-	c.Assert(sb.String(), Equals, "``;`abc`;`ab``c`;`ab````c`;`ab`` ``c`;")
-}
-
 // CleanNodeText set the text of node and all child node empty.
 // For test only.
 func CleanNodeText(node Node) {
@@ -100,7 +85,7 @@ func RunNodeRestoreTest(c *C, nodeTestCases []NodeRestoreTestCase, template stri
 		comment := Commentf("source %#v", testCase)
 		c.Assert(err, IsNil, comment)
 		var sb strings.Builder
-		err = extractNodeFunc(stmt).Restore(&sb)
+		err = extractNodeFunc(stmt).Restore(NewRestoreCtx(DefaultRestoreFlags, &sb))
 		c.Assert(err, IsNil, comment)
 		restoreSql := fmt.Sprintf(template, sb.String())
 		comment = Commentf("source %#v; restore %v", testCase, restoreSql)

--- a/go.mod1
+++ b/go.mod1
@@ -15,3 +15,5 @@ require (
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816
 	golang.org/x/text v0.3.0
 )
+
+replace github.com/pingcap/tidb => github.com/leoppro/tidb v0.0.0-00000000000000-4efb42782bbc7b9589ebf4afb2f82416c7a76fa6

--- a/go.sum1
+++ b/go.sum1
@@ -109,6 +109,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/leoppro/tidb v0.0.0-00000000000000-4efb42782bbc7b9589ebf4afb2f82416c7a76fa6 h1:vL8ufDZSej81fZPvtt+f0JfRzS8fftN8sppiUElL7pE=
+github.com/leoppro/tidb v0.0.0-00000000000000-4efb42782bbc7b9589ebf4afb2f82416c7a76fa6/go.mod h1:IyGiL3VYEWgyM3iNMLD7BTA6T51EYDoJF3jnc4Hdivo=
 github.com/leoppro/tidb v0.0.0-00000000000000-5791a57a03b7 h1:t9oZ5f5OO46px5blv5m45vFGxT1Ee97BF0fKYrLmj2s=
 github.com/leoppro/tidb v0.0.0-00000000000000-5791a57a03b7/go.mod h1:B8fFZPvn+zh0LEJODdc+br1SRRbljoZakm3ATyH0JuY=
 github.com/leoppro/tidb v0.0.0-00000000000000-812fd5698f7b h1:RGNCcA7g6cl0x6Dk9FjxLC9XHRggitWe4lH7EvewyaA=
@@ -155,6 +157,7 @@ github.com/pingcap/kvproto v0.0.0-20181105061835-1b5d69cd1d26/go.mod h1:0gwbe1F2
 github.com/pingcap/parser v0.0.0-20181102070703-4acd198f5092/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/parser v0.0.0-20181120072820-10951bcfca73/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/parser v0.0.0-20181126111651-a38036a60de7/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20181212042131-f20218bc2903/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
 github.com/pingcap/tidb v0.0.0-20181105182855-379ee5b1915a h1:Qd8qbDnsmAIXxefGBgFrWh4y0GDO6froUNFqZYmC568=
@@ -206,6 +209,7 @@ github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/struCoder/pidusage v0.1.2/go.mod h1:pWBlW3YuSwRl6h7R5KbvA4N8oOqe9LjaKW5CwT1SPjI=
 github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6 h1:lYIiVDtZnyTWlNwiAxLj0bbpTcx1BWCFhXjfsvmPdNc=

--- a/opcode/opcode.go
+++ b/opcode/opcode.go
@@ -145,5 +145,5 @@ func (o Op) Restore(w io.Writer) error {
 		fmt.Fprint(w, v)
 		return nil
 	}
-	return errors.Errorf("Invalid opcode type: %d", o)
+	return errors.Errorf("Invalid opcode type %d during restoring AST to SQL text", o)
 }

--- a/opcode/opcode.go
+++ b/opcode/opcode.go
@@ -16,6 +16,8 @@ package opcode
 import (
 	"fmt"
 	"io"
+
+	"github.com/pingcap/errors"
 )
 
 // Op is opcode type.
@@ -135,4 +137,13 @@ var opsLiteral = map[Op]string{
 // Format the ExprNode into a Writer.
 func (o Op) Format(w io.Writer) {
 	fmt.Fprintf(w, "%s", opsLiteral[o])
+}
+
+// Restore the Op into a Writer
+func (o Op) Restore(w io.Writer) error {
+	if v, ok := opsLiteral[o]; ok {
+		_, _ = fmt.Fprint(w, v)
+		return nil
+	}
+	return errors.Errorf("Invalid opcode type: %d", o)
 }

--- a/opcode/opcode.go
+++ b/opcode/opcode.go
@@ -142,7 +142,7 @@ func (o Op) Format(w io.Writer) {
 // Restore the Op into a Writer
 func (o Op) Restore(w io.Writer) error {
 	if v, ok := opsLiteral[o]; ok {
-		_, _ = fmt.Fprint(w, v)
+		fmt.Fprint(w, v)
 		return nil
 	}
 	return errors.Errorf("Invalid opcode type: %d", o)

--- a/parser_test.go
+++ b/parser_test.go
@@ -278,7 +278,7 @@ func (s *testParserSuite) RunRestoreTest(c *C, sourceSQLs, expectSQLs string) {
 	c.Assert(err, IsNil, comment)
 	restoreSQLs := ""
 	for _, stmt := range stmts {
-		err = stmt.Restore(&sb)
+		err = stmt.Restore(ast.NewRestoreCtx(ast.DefaultRestoreFlags, &sb))
 		c.Assert(err, IsNil, comment)
 		restoreSQL := sb.String()
 		comment = Commentf("source %v; restore %v", sourceSQLs, restoreSQL)


### PR DESCRIPTION
add RestoreCtx to output in many formats

See: pingcap/tidb#8679

support flags for restore function, we can control the format of output sql text by flags

Update proposal pr: pingcap/tidb#8694


### About `go.mod1`:
we have to update code(`parser` and `tidb`) at the same time when we change the `Node` interface  because parser and tidb are cyclic dependency.
in order to compile successfully, i have to replace `pingcap/tidb` with `leoppro/tidb` temporarily (and also repale `pingcap/parser` with `leoppro/parser` in tidb).
i will follow this to handle the dependence problem:
1. merge this pr
2. change go.mod of pingcap/tidb#8679, update dependency `pingcap/parser` to master
3. merge pingcap/tidb#8679
4. commit a pr to pingcap/parser,change dependency tidb to master