### PR TITLE
parser: implement Restore for DefaultExpr

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -523,7 +523,15 @@ type DefaultExpr struct {
 
 // Restore implements Node interface.
 func (n *DefaultExpr) Restore(ctx *RestoreCtx) error {
-	return errors.New("Not implemented")
+	ctx.WriteKeyWord("DEFAULT")
+	if n.Name != nil {
+		ctx.WritePlain("(")
+		if err := n.Name.Restore(ctx); err != nil {
+			return errors.Annotate(err, "An error occurred while restore DefaultExpr.Name")
+		}
+		ctx.WritePlain(")")
+	}
+	return nil
 }
 
 // Format the ExprNode into a Writer.

--- a/ast/expressions_test.go
+++ b/ast/expressions_test.go
@@ -208,3 +208,14 @@ func (tc *testExpressionsSuite) TestWhenClause(c *C) {
 	}
 	RunNodeRestoreTest(c, testCases, "select case %s end", extractNodeFunc)
 }
+
+func (tc *testExpressionsSuite) TestDefaultExpr(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"default", "DEFAULT"},
+		{"default(i)", "DEFAULT(`i`)"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node.(*InsertStmt).Lists[0][0]
+	}
+	RunNodeRestoreTest(c, testCases, "insert into t values(%s)", extractNodeFunc)
+}


### PR DESCRIPTION
Implement `Restore` and unit test for `DefaultExpr`.

Issue: https://github.com/pingcap/tidb/issues/8532