### PR TITLE
parser: implement Restore for IndexOption

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -363,28 +363,29 @@ type IndexOption struct {
 
 // Restore implements Node interface.
 func (n *IndexOption) Restore(ctx *RestoreCtx) error {
+	hasPrevOption := false
 	if n.KeyBlockSize > 0 {
 		ctx.WriteKeyWord("KEY_BLOCK_SIZE")
-		ctx.WritePlain("=")
-		ctx.WritePlainf("%d", n.KeyBlockSize)
-	}
-
-	if n.KeyBlockSize > 0 && n.Tp != model.IndexTypeInvalid {
-		ctx.WritePlain(" ")
+		ctx.WritePlainf("=%d", n.KeyBlockSize)
+		hasPrevOption = true
 	}
 
 	if n.Tp != model.IndexTypeInvalid {
+		if hasPrevOption {
+			ctx.WritePlain(" ")
+		}
 		ctx.WriteKeyWord("USING ")
 		ctx.WritePlain(n.Tp.String())
-	}
-
-	if n.Tp != model.IndexTypeInvalid && n.Comment != "" {
-		ctx.WritePlain(" ")
+		hasPrevOption = true
 	}
 
 	if n.Comment != "" {
+		if hasPrevOption {
+			ctx.WritePlain(" ")
+		}
 		ctx.WriteKeyWord("COMMENT ")
 		ctx.WriteString(n.Comment)
+		hasPrevOption = true
 	}
 	return nil
 }

--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/types"
-	"strconv"
 )
 
 var (
@@ -365,15 +364,26 @@ type IndexOption struct {
 // Restore implements Node interface.
 func (n *IndexOption) Restore(ctx *RestoreCtx) error {
 	if n.KeyBlockSize > 0 {
-		ctx.WriteKeyWord(" KEY_BLOCK_SIZE = ")
-		ctx.WritePlain(strconv.FormatUint(n.KeyBlockSize, 10))
+		ctx.WriteKeyWord("KEY_BLOCK_SIZE")
+		ctx.WritePlain("=")
+		ctx.WritePlainf("%d", n.KeyBlockSize)
 	}
-	if n.Tp == model.IndexTypeBtree || n.Tp == model.IndexTypeHash {
-		ctx.WriteKeyWord(" USING ")
+
+	if n.KeyBlockSize > 0 && n.Tp != model.IndexTypeInvalid {
+		ctx.WritePlain(" ")
+	}
+
+	if n.Tp != model.IndexTypeInvalid {
+		ctx.WriteKeyWord("USING ")
 		ctx.WritePlain(n.Tp.String())
 	}
+
+	if n.Tp != model.IndexTypeInvalid && n.Comment != "" {
+		ctx.WritePlain(" ")
+	}
+
 	if n.Comment != "" {
-		ctx.WriteKeyWord(" COMMENT ")
+		ctx.WriteKeyWord("COMMENT ")
 		ctx.WriteString(n.Comment)
 	}
 	return nil

--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/types"
+	"strconv"
 )
 
 var (
@@ -363,7 +364,19 @@ type IndexOption struct {
 
 // Restore implements Node interface.
 func (n *IndexOption) Restore(ctx *RestoreCtx) error {
-	return errors.New("Not implemented")
+	if n.KeyBlockSize > 0 {
+		ctx.WriteKeyWord(" KEY_BLOCK_SIZE = ")
+		ctx.WritePlain(strconv.FormatUint(n.KeyBlockSize, 10))
+	}
+	if n.Tp == model.IndexTypeBtree || n.Tp == model.IndexTypeHash {
+		ctx.WriteKeyWord(" USING ")
+		ctx.WritePlain(n.Tp.String())
+	}
+	if n.Comment != "" {
+		ctx.WriteKeyWord(" COMMENT ")
+		ctx.WriteString(n.Comment)
+	}
+	return nil
 }
 
 // Accept implements Node Accept interface.

--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -385,7 +385,6 @@ func (n *IndexOption) Restore(ctx *RestoreCtx) error {
 		}
 		ctx.WriteKeyWord("COMMENT ")
 		ctx.WriteString(n.Comment)
-		hasPrevOption = true
 	}
 	return nil
 }

--- a/ast/ddl_test.go
+++ b/ast/ddl_test.go
@@ -62,3 +62,20 @@ func (ts *testDDLSuite) TestDDLVisitorCover(c *C) {
 		v.node.Accept(visitor1{})
 	}
 }
+
+func (ts *testDDLSuite) TestDDLIndexOption(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"key_block_size=16"," KEY_BLOCK_SIZE = 16"},
+		{"USING HASH"," USING HASH"},
+		{"comment 'hello'"," COMMENT 'hello'"},
+		{"key_block_size=16 USING HASH"," KEY_BLOCK_SIZE = 16 USING HASH"},
+		{"USING HASH KEY_BLOCK_SIZE=16"," KEY_BLOCK_SIZE = 16 USING HASH"},
+		{"COMMENT 'foo'"," COMMENT 'foo'"},
+		{"key_block_size = 32 using hash comment 'hello'"," KEY_BLOCK_SIZE = 32 USING HASH COMMENT 'hello'"},
+		{"key_block_size=32 using btree comment 'hello'"," KEY_BLOCK_SIZE = 32 USING BTREE COMMENT 'hello'"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node.(*CreateIndexStmt).IndexOption
+	}
+	RunNodeRestoreTest(c, testCases, "CREATE INDEX idx ON t (a)%s", extractNodeFunc)
+}

--- a/ast/ddl_test.go
+++ b/ast/ddl_test.go
@@ -65,17 +65,18 @@ func (ts *testDDLSuite) TestDDLVisitorCover(c *C) {
 
 func (ts *testDDLSuite) TestDDLIndexOption(c *C) {
 	testCases := []NodeRestoreTestCase{
-		{"key_block_size=16"," KEY_BLOCK_SIZE = 16"},
-		{"USING HASH"," USING HASH"},
-		{"comment 'hello'"," COMMENT 'hello'"},
-		{"key_block_size=16 USING HASH"," KEY_BLOCK_SIZE = 16 USING HASH"},
-		{"USING HASH KEY_BLOCK_SIZE=16"," KEY_BLOCK_SIZE = 16 USING HASH"},
-		{"COMMENT 'foo'"," COMMENT 'foo'"},
-		{"key_block_size = 32 using hash comment 'hello'"," KEY_BLOCK_SIZE = 32 USING HASH COMMENT 'hello'"},
-		{"key_block_size=32 using btree comment 'hello'"," KEY_BLOCK_SIZE = 32 USING BTREE COMMENT 'hello'"},
+		{"key_block_size=16","KEY_BLOCK_SIZE=16"},
+		{"USING HASH","USING HASH"},
+		{"comment 'hello'","COMMENT 'hello'"},
+		{"key_block_size=16 USING HASH","KEY_BLOCK_SIZE=16 USING HASH"},
+		{"USING HASH KEY_BLOCK_SIZE=16","KEY_BLOCK_SIZE=16 USING HASH"},
+		{"USING HASH COMMENT 'foo'","USING HASH COMMENT 'foo'"},
+		{"COMMENT 'foo'","COMMENT 'foo'"},
+		{"key_block_size = 32 using hash comment 'hello'","KEY_BLOCK_SIZE=32 USING HASH COMMENT 'hello'"},
+		{"key_block_size=32 using btree comment 'hello'","KEY_BLOCK_SIZE=32 USING BTREE COMMENT 'hello'"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*CreateIndexStmt).IndexOption
 	}
-	RunNodeRestoreTest(c, testCases, "CREATE INDEX idx ON t (a)%s", extractNodeFunc)
+	RunNodeRestoreTest(c, testCases, "CREATE INDEX idx ON t (a) %s", extractNodeFunc)
 }

--- a/parser.go
+++ b/parser.go
@@ -8563,6 +8563,8 @@ yynewstate:
 					opt1.Comment = opt2.Comment
 				} else if opt2.Tp != 0 {
 					opt1.Tp = opt2.Tp
+				} else if opt2.KeyBlockSize > 0 {
+					opt1.KeyBlockSize = opt2.KeyBlockSize
 				}
 				parser.yyVAL.item = opt1
 			}
@@ -8571,7 +8573,7 @@ yynewstate:
 		{
 			parser.yyVAL.item = &ast.IndexOption{
 				// TODO bug should be fix here!
-				// KeyBlockSize: $1.(uint64),
+				KeyBlockSize: yyS[yypt-0].item.(uint64),
 			}
 		}
 	case 342:

--- a/parser.y
+++ b/parser.y
@@ -2926,6 +2926,8 @@ IndexOptionList:
 				opt1.Comment = opt2.Comment
 			} else if opt2.Tp != 0 {
 				opt1.Tp = opt2.Tp
+			} else if opt2.KeyBlockSize > 0 {
+			    opt1.KeyBlockSize = opt2.KeyBlockSize
 			}
 			$$ = opt1
 		}
@@ -2937,7 +2939,7 @@ IndexOption:
 	{
 		$$ = &ast.IndexOption{
 			// TODO bug should be fix here!
-			// KeyBlockSize: $1.(uint64),
+			KeyBlockSize: $3.(uint64),
 		}
 	}
 |	IndexType


### PR DESCRIPTION
1. implement Restore for IndexOption
2. Add indexOption goyacc code
3. Add indexOptionList goyacc code

---

Issue: [https://github.com/pingcap/tidb/issues/8532](https://github.com/pingcap/tidb/issues/8532)