### PR TITLE
fix hint handle bug in subquery

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -10480,6 +10480,7 @@ yynewstate:
 		{
 			yyerrok()
 			parser.lastErrorAsWarn()
+			parser.yyVAL.item = nil
 		}
 	case 979:
 		{

--- a/parser.y
+++ b/parser.y
@@ -5195,6 +5195,7 @@ TableOptimizerHints:
 	{
 		yyerrok()
 		parser.lastErrorAsWarn()
+		$$ = nil
 	}
 
 HintTableList:

--- a/parser_test.go
+++ b/parser_test.go
@@ -1839,6 +1839,8 @@ func (s *testParserSuite) TestHintError(c *C) {
 	c.Assert(err, NotNil)
 	stmt, _, err = parser.Parse("select /*+ TIDB_INLJ(t1, T2) */ c1, c2 fromt t1, t2 where t1.c1 = t2.c1", "", "")
 	c.Assert(err, NotNil)
+	_, _, err = parser.Parse("SELECT 1 FROM DUAL WHERE 1 IN (SELECT /*+ DEBUG_HINT3 */ 1)", "", "")
+	c.Assert(err, IsNil)
 }
 
 func (s *testParserSuite) TestOptimizerHints(c *C) {


### PR DESCRIPTION
###  question

```
 	_, _, err = parser.Parse("SELECT 1 FROM DUAL WHERE 1 IN (SELECT /*+ DEBUG_HINT3 */ 1)", "", "")
 	c.Assert(err, IsNil)
```

will be fail in current master code

### why 

parser are try its best to reuse yySymType (https://github.com/pingcap/parser/blob/947d4ab3052f1ca608820e8dd5dd1d8c0c838fdf/yy_parser.go#L68)

what happen in here is ` /*+ DEBUG_HINT3 */` reuse `1` of `1 IN ` and doesn't reset.

we should never forgot set `$ = nil` if we want it be `nil` :rofl: 

### fix

reset `$=nil`


