### PR TITLE
makefile: add fmt command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ ARCH:="`uname -s`"
 MAC:="Darwin"
 LINUX:="Linux"
 
-all: parser.go
+all: parser.go fmt
 
-test: parser.go
+test: parser.go fmt
 	sh test.sh
 
 parser.go: parser.y
@@ -30,6 +30,10 @@ parser: bin/goyacc
 
 bin/goyacc: goyacc/main.go
 	GO111MODULE=on go build -o bin/goyacc goyacc/main.go
+
+fmt:
+	@echo "gofmt (simplify)"
+	@ gofmt -s -l -w . 2>&1 | awk '{print} END{if(NR>0) {exit 1}}'
 
 clean:
 	go clean -i ./...

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ jobs:
             diff -u parser.go.committed parser.go
       - run:
           name: "Check code format"
-          command: gofmt -l -s . | awk '{print} END{if(NR>0) {exit 1}}'
+          command: make fmt
       - run:
           name: "Build & Test"
           command: make test


### PR DESCRIPTION
In order to avoid the wrong format submitted by contributors, i add `fmt` command in Makefile to run `gofmt` and it will be execute at `make test` automatically.