### PR TITLE
parser: implement Restore for PositionExpr, ByItem and GroupByClause

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -579,7 +579,13 @@ type ByItem struct {
 
 // Restore implements Node interface.
 func (n *ByItem) Restore(ctx *RestoreCtx) error {
-	return errors.New("Not implemented")
+	if err := n.Expr.Restore(ctx); err != nil {
+		return errors.Annotate(err, "An error occurred while restore ByItem.Expr")
+	}
+	if n.Desc {
+		ctx.WriteKeyWord(" DESC")
+	}
+	return nil
 }
 
 // Accept implements Node Accept interface.
@@ -605,7 +611,15 @@ type GroupByClause struct {
 
 // Restore implements Node interface.
 func (n *GroupByClause) Restore(ctx *RestoreCtx) error {
-	return errors.New("Not implemented")
+	for i, v := range n.Items {
+		if i != 0 {
+			ctx.WritePlain(",")
+		}
+		if err := v.Restore(ctx); err != nil {
+			return errors.Annotatef(err, "An error occurred while restore GroupByClause.Items[%d]", i)
+		}
+	}
+	return nil
 }
 
 // Accept implements Node Accept interface.

--- a/ast/dml_test.go
+++ b/ast/dml_test.go
@@ -225,3 +225,25 @@ func (tc *testDMLSuite) TestDeleteTableListRestore(c *C) {
 	RunNodeRestoreTest(c, testCases, "DELETE %s FROM t1, t2;", extractNodeFunc)
 	RunNodeRestoreTest(c, testCases, "DELETE FROM %s USING t1, t2;", extractNodeFunc)
 }
+func (tc *testExpressionsSuite) TestByItemRestore(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"a", "`a`"},
+		{"a desc", "`a` DESC"},
+		{"NULL", "NULL"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node.(*SelectStmt).OrderBy.Items[0]
+	}
+	RunNodeRestoreTest(c, testCases, "select * from t order by %s", extractNodeFunc)
+}
+
+func (tc *testExpressionsSuite) TestGroupByClauseRestore(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"a,b desc", "`a`,`b` DESC"},
+		{"1 desc,b", "1 DESC,`b`"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node.(*SelectStmt).GroupBy
+	}
+	RunNodeRestoreTest(c, testCases, "select * from t group by %s", extractNodeFunc)
+}

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -898,7 +898,8 @@ type PositionExpr struct {
 
 // Restore implements Node interface.
 func (n *PositionExpr) Restore(ctx *RestoreCtx) error {
-	return errors.New("Not implemented")
+	ctx.WritePlainf("%d", n.N)
+	return nil
 }
 
 // Format the ExprNode into a Writer.

--- a/ast/expressions_test.go
+++ b/ast/expressions_test.go
@@ -301,3 +301,13 @@ func (tc *testExpressionsSuite) TestMaxValueExprRestore(c *C) {
 	}
 	RunNodeRestoreTest(c, testCases, "alter table posts add partition ( partition p1 values less than %s)", extractNodeFunc)
 }
+
+func (tc *testExpressionsSuite) TestPositionExprRestore(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"1", "1"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node.(*SelectStmt).OrderBy.Items[0]
+	}
+	RunNodeRestoreTest(c, testCases, "select * from t order by %s", extractNodeFunc)
+}


### PR DESCRIPTION
Implement `Restore` and unit tests for `PositionExpr`, `ByItem` and `GroupByClause`.

Issue: https://github.com/pingcap/tidb/issues/8532