### PR TITLE
parser: implement Restore for OrderByClause

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -674,7 +674,16 @@ type OrderByClause struct {
 
 // Restore implements Node interface.
 func (n *OrderByClause) Restore(ctx *RestoreCtx) error {
-	return errors.New("Not implemented")
+	ctx.WriteKeyWord("ORDER BY ")
+	for i, item := range n.Items {
+		if i != 0 {
+			ctx.WritePlain(",")
+		}
+		if err := item.Restore(ctx); err != nil {
+			return errors.Annotatef(err, "An error occurred while restore OrderByClause.Items[%d]", i)
+		}
+	}
+	return nil
 }
 
 // Accept implements Node Accept interface.

--- a/ast/dml_test.go
+++ b/ast/dml_test.go
@@ -247,3 +247,19 @@ func (tc *testExpressionsSuite) TestGroupByClauseRestore(c *C) {
 	}
 	RunNodeRestoreTest(c, testCases, "select * from t group by %s", extractNodeFunc)
 }
+
+func (tc *testDMLSuite) TestOrderByClauseRestore(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"ORDER BY a", "ORDER BY `a`"},
+		{"ORDER BY a,b", "ORDER BY `a`,`b`"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node.(*SelectStmt).OrderBy
+	}
+	RunNodeRestoreTest(c, testCases, "SELECT 1 FROM t1 %s", extractNodeFunc)
+
+	extractNodeFromUnionStmtFunc := func(node Node) Node {
+		return node.(*UnionStmt).OrderBy
+	}
+	RunNodeRestoreTest(c, testCases, "SELECT 1 FROM t1 UNION SELECT 2 FROM t2 %s", extractNodeFromUnionStmtFunc)
+}


### PR DESCRIPTION
Implement Restore and unit tests for OrderByClause

Issue: pingcap/tidb#8532

ps: 
I'm confused about the meaning of field `OrderByClause.ForUnion`.
Does it mean using order by clause in a union query?