### PR TITLE
add drop view ddl action

### DIFF
--- a/model/ddl.go
+++ b/model/ddl.go
@@ -53,6 +53,8 @@ const (
 	ActionCreateView                   ActionType = 21
 	ActionModifyTableCharsetAndCollate ActionType = 22
 	ActionTruncateTablePartition       ActionType = 23
+	ActionDropTableOrView              ActionType = 24
+	ActionDropView                     ActionType = 25
 )
 
 // AddIndexStr is a string related to the operation of "add index".
@@ -82,6 +84,8 @@ var actionMap = map[ActionType]string{
 	ActionCreateView:                   "create view",
 	ActionModifyTableCharsetAndCollate: "modify table charset and collate",
 	ActionTruncateTablePartition:       "truncate partition",
+	ActionDropTableOrView:              "drop table or view",
+	ActionDropView:                     "drop view",
 }
 
 // String return current ddl action in string

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -53,8 +53,7 @@ const (
 	ActionCreateView                   ActionType = 21
 	ActionModifyTableCharsetAndCollate ActionType = 22
 	ActionTruncateTablePartition       ActionType = 23
-	ActionDropTableOrView              ActionType = 24
-	ActionDropView                     ActionType = 25
+	ActionDropView                     ActionType = 24
 )
 
 // AddIndexStr is a string related to the operation of "add index".
@@ -84,7 +83,6 @@ var actionMap = map[ActionType]string{
 	ActionCreateView:                   "create view",
 	ActionModifyTableCharsetAndCollate: "modify table charset and collate",
 	ActionTruncateTablePartition:       "truncate partition",
-	ActionDropTableOrView:              "drop table or view",
 	ActionDropView:                     "drop view",
 }
 


### PR DESCRIPTION
Part of View feature implement, add drop view action to handle drop view func.

Because most of `DropTable` and `DropView` code logical is the same, so I think we can use `ActionTruncateTablePartition` to pass operation type. and we can use `ActionDropTable` and `ActionDropView` for different logical part.