### PR TITLE
parser: implement Restore for OnCondition

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -118,8 +118,8 @@ func (n *Join) Restore(ctx *RestoreCtx) error {
 	ctx.JoinLevel--
 
 	if n.On != nil {
-		ctx.WriteKeyWord(" ON ")
-		if err := n.On.Expr.Restore(ctx); err != nil {
+		ctx.WritePlain(" ")
+		if err := n.On.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore Join.On")
 		}
 	}
@@ -325,7 +325,11 @@ type OnCondition struct {
 
 // Restore implements Node interface.
 func (n *OnCondition) Restore(ctx *RestoreCtx) error {
-	return errors.New("Not implemented")
+	ctx.WriteKeyWord("ON ")
+	if err := n.Expr.Restore(ctx); err != nil {
+		return errors.Annotate(err, "An error occurred while restore OnCondition.Expr")
+	}
+	return nil
 }
 
 // Accept implements Node Accept interface.

--- a/ast/dml_test.go
+++ b/ast/dml_test.go
@@ -193,6 +193,17 @@ func (tc *testDMLSuite) TestTableSourceRestore(c *C) {
 	RunNodeRestoreTest(c, testCases, "select * from %s", extractNodeFunc)
 }
 
+func (tc *testDMLSuite) TestOnConditionRestore(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"on t1.a=t2.a", "ON `t1`.`a`=`t2`.`a`"},
+		{"on t1.a=t2.a and t1.b=t2.b", "ON `t1`.`a`=`t2`.`a`&&`t1`.`b`=`t2`.`b`"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node.(*SelectStmt).From.TableRefs.On
+	}
+	RunNodeRestoreTest(c, testCases, "select * from t1 join t2 %s", extractNodeFunc)
+}
+
 func (tc *testDMLSuite) TestJoinRestore(c *C) {
 	testCases := []NodeRestoreTestCase{
 		{"t1 natural join t2", "`t1` NATURAL JOIN `t2`"},


### PR DESCRIPTION
Implement `Restore` and unit test for `OnCondition`. Fix `Restore` of `Join`.

Issue: https://github.com/pingcap/tidb/issues/8532