### PR TITLE
parser: implement Restore for FrameBound

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -14,6 +14,8 @@
 package ast
 
 import (
+	"strings"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
@@ -1535,17 +1537,12 @@ func (n *FrameBound) Restore(ctx *RestoreCtx) error {
 			}
 		}
 		if n.Unit != nil {
-			// Here the Unit string should not be quoted
-			singleQuotesFlag := ctx.Flags & RestoreStringSingleQuotes
-			doubleQuotesFlag := ctx.Flags & RestoreStringDoubleQuotes
-			ctx.Flags &= ^RestoreStringSingleQuotes
-			ctx.Flags &= ^RestoreStringDoubleQuotes
+			// Here the Unit string should not be quoted.
+			// TODO: This is a temporary workaround that should be changed once something like "Keyword Expression" is implemented.
+			var sb strings.Builder
+			n.Unit.Restore(NewRestoreCtx(0, &sb))
 			ctx.WritePlain(" ")
-			if err := n.Unit.Restore(ctx); err != nil {
-				return errors.Annotate(err, "An error occurred while restore FrameBound.Unit")
-			}
-			ctx.Flags |= singleQuotesFlag
-			ctx.Flags |= doubleQuotesFlag
+			ctx.WriteKeyWord(sb.String())
 		}
 		if n.Type == Preceding {
 			ctx.WriteKeyWord(" PRECEDING")

--- a/ast/dml_test.go
+++ b/ast/dml_test.go
@@ -275,3 +275,21 @@ func (ts *testDMLSuite) TestHavingClauseRestore(c *C) {
 	}
 	RunNodeRestoreTest(c, testCases, "select 1 from t1 group by 1 %s", extractNodeFunc)
 }
+
+func (ts *testDMLSuite) TestFrameBoundRestore(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"CURRENT ROW", "CURRENT ROW"},
+		{"UNBOUNDED PRECEDING", "UNBOUNDED PRECEDING"},
+		{"1 PRECEDING", "1 PRECEDING"},
+		{"? PRECEDING", "? PRECEDING"},
+		{"INTERVAL 5 DAY PRECEDING", "INTERVAL 5 DAY PRECEDING"},
+		{"UNBOUNDED FOLLOWING", "UNBOUNDED FOLLOWING"},
+		{"1 FOLLOWING", "1 FOLLOWING"},
+		{"? FOLLOWING", "? FOLLOWING"},
+		{"INTERVAL '2:30' MINUTE_SECOND FOLLOWING", "INTERVAL '2:30' MINUTE_SECOND FOLLOWING"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return &node.(*SelectStmt).Fields.Fields[0].Expr.(*WindowFuncExpr).Spec.Frame.Extent.Start
+	}
+	RunNodeRestoreTest(c, testCases, "select avg(val) over (rows between %s and current row) from t", extractNodeFunc)
+}

--- a/ast/util_test.go
+++ b/ast/util_test.go
@@ -116,6 +116,7 @@ type NodeRestoreTestCase struct {
 
 func RunNodeRestoreTest(c *C, nodeTestCases []NodeRestoreTestCase, template string, extractNodeFunc func(node Node) Node) {
 	parser := parser.New()
+	parser.EnableWindowFunc(true)
 	for _, testCase := range nodeTestCases {
 		sourceSQL := fmt.Sprintf(template, testCase.sourceSQL)
 		expectSQL := fmt.Sprintf(template, testCase.expectSQL)

--- a/parser.go
+++ b/parser.go
@@ -10061,7 +10061,7 @@ yynewstate:
 		}
 	case 884:
 		{
-			parser.yyVAL.item = ast.FrameBound{Type: ast.Preceding, Expr: ast.NewValueExpr(yyS[yypt-1].item)}
+			parser.yyVAL.item = ast.FrameBound{Type: ast.Preceding, Expr: ast.NewParamMarkerExpr(yyS[yypt].offset)}
 		}
 	case 885:
 		{
@@ -10089,7 +10089,7 @@ yynewstate:
 		}
 	case 891:
 		{
-			parser.yyVAL.item = ast.FrameBound{Type: ast.Following, Expr: ast.NewValueExpr(yyS[yypt-1].item)}
+			parser.yyVAL.item = ast.FrameBound{Type: ast.Following, Expr: ast.NewParamMarkerExpr(yyS[yypt].offset)}
 		}
 	case 892:
 		{

--- a/parser.y
+++ b/parser.y
@@ -4714,7 +4714,7 @@ WindowFrameStart:
 	}
 |	paramMarker "PRECEDING"
 	{
-		$$ = ast.FrameBound{Type: ast.Preceding, Expr: ast.NewValueExpr($1),}
+		$$ = ast.FrameBound{Type: ast.Preceding, Expr: ast.NewParamMarkerExpr(yyS[yypt].offset),}
 	}
 |	"INTERVAL" Expression TimeUnit "PRECEDING"
 	{
@@ -4746,7 +4746,7 @@ WindowFrameBound:
 	}
 |	paramMarker "FOLLOWING"
 	{
-		$$ = ast.FrameBound{Type: ast.Following, Expr: ast.NewValueExpr($1),}
+		$$ = ast.FrameBound{Type: ast.Following, Expr: ast.NewParamMarkerExpr(yyS[yypt].offset),}
 	}
 |	"INTERVAL" Expression TimeUnit "FOLLOWING"
 	{


### PR DESCRIPTION
Implement `Restore` and unit test for `FrameBound`.

I changed two lines in `parser.y`, though not sure it is completely right.

Issue: https://github.com/pingcap/tidb/issues/8532