### PR TITLE
parser: implement Restore for TableOptimizerHint

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -16,6 +16,7 @@ package ast
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -984,7 +985,20 @@ type TableOptimizerHint struct {
 
 // Restore implements Node interface.
 func (n *TableOptimizerHint) Restore(ctx *RestoreCtx) error {
-	return errors.New("Not implemented")
+	ctx.WriteKeyWord(n.HintName.String())
+	ctx.WritePlain("(")
+	if len(n.Tables) > 0 {
+		for i, v := range n.Tables {
+			if i != 0 {
+				ctx.WritePlain(",")
+			}
+			ctx.WriteName(v.String())
+		}
+	} else {
+		ctx.WritePlain(strconv.FormatUint(n.MaxExecutionTime, 10))
+	}
+	ctx.WritePlain(")")
+	return nil
 }
 
 // Accept implements Node Accept interface.

--- a/ast/misc_test.go
+++ b/ast/misc_test.go
@@ -188,3 +188,18 @@ func (ts *testMiscSuite) TestUserSpec(c *C) {
 	c.Assert(ok, IsTrue)
 	c.Assert(pwd, Equals, "")
 }
+
+func (ts *testMiscSuite) TestTableOptimizerHintRestore(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"TIDB_SMJ(`t1`)", "TIDB_SMJ(`t1`)"},
+		// {"TIDB_SMJ(t1)", "TIDB_SMJ(`t1`)"},
+		// {"TIDB_SMJ(t1,t2)", "TIDB_SMJ(`t1`,`t2`)"},
+		// {"TIDB_INLJ(t1,t2)", "TIDB_INLJ(`t1`,`t2`)"},
+		// {"TIDB_HJ(t1,t2)", "TIDB_HJ(`t1`,`t2`)"},
+		{"MAX_EXECUTION_TIME(3000)", "MAX_EXECUTION_TIME(3000)"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node.(*SelectStmt).TableHints[0]
+	}
+	RunNodeRestoreTest(c, testCases, "select /*+ %s */ * from t1 join t2", extractNodeFunc)
+}


### PR DESCRIPTION
Impletment `Restore` and unit test for `TableOptimizerHint`.

Issue: https://github.com/pingcap/tidb/issues/8532

---

Here is a problem that should be resolved before moving on to `SelectStmt`. The `SelectField`s of the following two queries are different:
1. `select /*+ TIDB_SMJ(t1) */ * from t1 join t2`
```
*ast.SelectStmt	&{{{{select /*+ TIDB_SMJ(t1) */ * from t1 join t2}}} {[]} 0xc00000f5c0 false 0xc00000a720 <nil> 0xc00000f5f0 <nil> <nil> [] <nil> <nil> none [0xc0000a6d20] false false}
  *ast.TableOptimizerHint	&{{} TIDB_SMJ [t1] 0}
  *ast.TableRefsClause	&{{} 0xc000146080}
    *ast.Join	&{{} {[]} 0xc000054340 0xc000054380 1 <nil> [] false false}
      *ast.TableSource	&{{} 0xc000144090 }
        *ast.TableName	&{{} {[]}  t1 <nil> <nil> []}
      *ast.TableSource	&{{} 0xc000144120 }
        *ast.TableName	&{{} {[]}  t2 <nil> <nil> []}
  *ast.FieldList	&{{} [0xc000058660]}
    *ast.SelectField	&{{} 27 0xc0000a6d70 <nil>  false}
```

2. ``select /*+ TIDB_SMJ(`t1`) */ * from t1 join t2``
```
*ast.SelectStmt	&{{{{select /*+ TIDB_SMJ(`t1`) */ * from t1 join t2}}} {[]} 0xc00000f5c0 false 0xc00000a760 <nil> 0xc00000f5f0 <nil> <nil> [] <nil> <nil> none [0xc0000a2d20] false false}
  *ast.TableOptimizerHint	&{{} TIDB_SMJ [t1] 0}
  *ast.TableRefsClause	&{{} 0xc000146080}
    *ast.Join	&{{} {[]} 0xc000054340 0xc000054380 1 <nil> [] false false}
      *ast.TableSource	&{{} 0xc000144090 }
        *ast.TableName	&{{} {[]}  t1 <nil> <nil> []}
      *ast.TableSource	&{{} 0xc000144120 }
        *ast.TableName	&{{} {[]}  t2 <nil> <nil> []}
  *ast.FieldList	&{{} [0xc000058660]}
    *ast.SelectField	&{{} 29 0xc0000a2d70 <nil>  false}
```

The only difference is `SelectField.Offset`, which will count the backquotes put by `Restore`. For this PR we can wrap identifiers in the source SQL text with backquotes, but there are hundreds of `select` test cases of `SelectStmt` and some shall not be handled this way. So any suggestion?
