### PR TITLE
parser: fix subquery in PatternInExpr.Restore and add tests

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -634,21 +634,22 @@ func (n *PatternInExpr) Restore(ctx *RestoreCtx) error {
 	} else {
 		ctx.WriteKeyWord(" IN ")
 	}
-	ctx.WritePlain("(")
-	for i, expr := range n.List {
-		if i != 0 {
-			ctx.WritePlain(",")
-		}
-		if err := expr.Restore(ctx); err != nil {
-			return errors.Annotatef(err, "An error occurred while restore PatternInExpr.List[%d]", i)
-		}
-	}
 	if n.Sel != nil {
 		if err := n.Sel.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore PatternInExpr.Sel")
 		}
+	} else {
+		ctx.WritePlain("(")
+		for i, expr := range n.List {
+			if i != 0 {
+				ctx.WritePlain(",")
+			}
+			if err := expr.Restore(ctx); err != nil {
+				return errors.Annotatef(err, "An error occurred while restore PatternInExpr.List[%d]", i)
+			}
+		}
+		ctx.WritePlain(")")
 	}
-	ctx.WritePlain(")")
 	return nil
 }
 

--- a/ast/expressions_test.go
+++ b/ast/expressions_test.go
@@ -239,9 +239,8 @@ func (tc *testExpressionsSuite) TestPatternInExprRestore(c *C) {
 		{"'a' in ('b')", "'a' IN ('b')"},
 		{"2 in (0,3,7)", "2 IN (0,3,7)"},
 		{"2 not in (0,3,7)", "2 NOT IN (0,3,7)"},
-		// TODO: Test for subquery when it's implemented
-		// 2 in (select 2)
-		// 2 not in (select 2)
+		{"2 in (select 2)", "2 IN (SELECT 2)"},
+		{"2 not in (select 2)", "2 NOT IN (SELECT 2)"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*SelectStmt).Fields.Fields[0].Expr


### PR DESCRIPTION
It's a supplement for my previous PR https://github.com/pingcap/parser/pull/92.