### PR TITLE
parser: support GOARCH=386 build

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -80,8 +80,8 @@ type TypeOpt struct {
 // FloatOpt is used for parsing floating-point type option from SQL.
 // See http://dev.mysql.com/doc/refman/5.7/en/floating-point-types.html
 type FloatOpt struct {
-	Flen    int
-	Decimal int
+	Flen    int64
+	Decimal int64
 }
 
 // AuthOption is used for parsing create use statement.

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -439,7 +439,7 @@ var DefaultLengthOfTimeFraction = map[int]int{
 
 // SQLMode is the type for MySQL sql_mode.
 // See https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html
-type SQLMode int
+type SQLMode int64
 
 // HasNoZeroDateMode detects if 'NO_ZERO_DATE' mode is set in SQLMode
 func (m SQLMode) HasNoZeroDateMode() bool {

--- a/mysql/util.go
+++ b/mysql/util.go
@@ -14,8 +14,8 @@
 package mysql
 
 type lengthAndDecimal struct {
-	length  int
-	decimal int
+	length  int64
+	decimal int64
 }
 
 // defaultLengthAndDecimal provides default Flen and Decimal for fields
@@ -62,7 +62,7 @@ func IsIntegerType(tp byte) bool {
 // or column value is calculated from an expression.
 // For example: "select count(*) from t;", the column type is int64 and Flen in ResultField will be 21.
 // See https://dev.mysql.com/doc/refman/5.7/en/storage-requirements.html
-func GetDefaultFieldLengthAndDecimal(tp byte) (flen int, decimal int) {
+func GetDefaultFieldLengthAndDecimal(tp byte) (flen int64, decimal int64) {
 	val, ok := defaultLengthAndDecimal[tp]
 	if ok {
 		return val.length, val.decimal
@@ -84,7 +84,7 @@ var defaultLengthAndDecimalForCast = map[byte]lengthAndDecimal{
 
 // GetDefaultFieldLengthAndDecimalForCast returns the default display length (flen) and decimal length for casted column
 // when flen or decimal is not specified.
-func GetDefaultFieldLengthAndDecimalForCast(tp byte) (flen int, decimal int) {
+func GetDefaultFieldLengthAndDecimalForCast(tp byte) (flen int64, decimal int64) {
 	val, ok := defaultLengthAndDecimalForCast[tp]
 	if ok {
 		return val.length, val.decimal

--- a/parser.go
+++ b/parser.go
@@ -9734,7 +9734,7 @@ yynewstate:
 	case 827:
 		{
 			x := types.NewFieldType(mysql.TypeVarString)
-			x.Flen = yyS[yypt-0].item.(int) // TODO: Flen should be the flen of expression
+			x.Flen = yyS[yypt-0].item.(int64) // TODO: Flen should be the flen of expression
 			if x.Flen != types.UnspecifiedLength {
 				x.Tp = mysql.TypeString
 			}
@@ -9746,7 +9746,7 @@ yynewstate:
 	case 828:
 		{
 			x := types.NewFieldType(mysql.TypeVarString)
-			x.Flen = yyS[yypt-1].item.(int) // TODO: Flen should be the flen of expression
+			x.Flen = yyS[yypt-1].item.(int64) // TODO: Flen should be the flen of expression
 			x.Charset = yyS[yypt-0].item.(*ast.OptBinary).Charset
 			if yyS[yypt-0].item.(*ast.OptBinary).IsBinary {
 				x.Flag |= mysql.BinaryFlag
@@ -9769,9 +9769,9 @@ yynewstate:
 		{
 			x := types.NewFieldType(mysql.TypeDatetime)
 			x.Flen, _ = mysql.GetDefaultFieldLengthAndDecimalForCast(mysql.TypeDatetime)
-			x.Decimal = yyS[yypt-0].item.(int)
+			x.Decimal = yyS[yypt-0].item.(int64)
 			if x.Decimal > 0 {
-				x.Flen = x.Flen + 1 + x.Decimal
+				x.Flen = x.Flen + 1 + int64(x.Decimal)
 			}
 			x.Charset = charset.CharsetBin
 			x.Collate = charset.CollationBin
@@ -9793,9 +9793,9 @@ yynewstate:
 		{
 			x := types.NewFieldType(mysql.TypeDuration)
 			x.Flen, _ = mysql.GetDefaultFieldLengthAndDecimalForCast(mysql.TypeDuration)
-			x.Decimal = yyS[yypt-0].item.(int)
+			x.Decimal = yyS[yypt-0].item.(int64)
 			if x.Decimal > 0 {
-				x.Flen = x.Flen + 1 + x.Decimal
+				x.Flen = x.Flen + 1 + int64(x.Decimal)
 			}
 			x.Charset = charset.CharsetBin
 			x.Collate = charset.CollationBin
@@ -11777,7 +11777,7 @@ yynewstate:
 		{
 			// TODO: check flen 0
 			x := types.NewFieldType(yyS[yypt-2].item.(byte))
-			x.Flen = yyS[yypt-1].item.(int)
+			x.Flen = yyS[yypt-1].item.(int64)
 			for _, o := range yyS[yypt-0].item.([]*ast.TypeOpt) {
 				if o.IsUnsigned {
 					x.Flag |= mysql.UnsignedFlag
@@ -11843,7 +11843,7 @@ yynewstate:
 	case 1263:
 		{
 			x := types.NewFieldType(yyS[yypt-1].item.(byte))
-			x.Flen = yyS[yypt-0].item.(int)
+			x.Flen = yyS[yypt-0].item.(int64)
 			if x.Flen == types.UnspecifiedLength || x.Flen == 0 {
 				x.Flen = 1
 			} else if x.Flen > 64 {
@@ -11938,7 +11938,7 @@ yynewstate:
 	case 1287:
 		{
 			x := types.NewFieldType(mysql.TypeString)
-			x.Flen = yyS[yypt-2].item.(int)
+			x.Flen = yyS[yypt-2].item.(int64)
 			x.Charset = yyS[yypt-1].item.(*ast.OptBinary).Charset
 			x.Collate = yyS[yypt-0].item.(string)
 			if yyS[yypt-1].item.(*ast.OptBinary).IsBinary {
@@ -11959,7 +11959,7 @@ yynewstate:
 	case 1289:
 		{
 			x := types.NewFieldType(mysql.TypeString)
-			x.Flen = yyS[yypt-2].item.(int)
+			x.Flen = yyS[yypt-2].item.(int64)
 			x.Charset = yyS[yypt-1].item.(*ast.OptBinary).Charset
 			x.Collate = yyS[yypt-0].item.(string)
 			if yyS[yypt-1].item.(*ast.OptBinary).IsBinary {
@@ -11970,7 +11970,7 @@ yynewstate:
 	case 1290:
 		{
 			x := types.NewFieldType(mysql.TypeVarchar)
-			x.Flen = yyS[yypt-2].item.(int)
+			x.Flen = yyS[yypt-2].item.(int64)
 			x.Charset = yyS[yypt-1].item.(*ast.OptBinary).Charset
 			x.Collate = yyS[yypt-0].item.(string)
 			if yyS[yypt-1].item.(*ast.OptBinary).IsBinary {
@@ -11981,7 +11981,7 @@ yynewstate:
 	case 1291:
 		{
 			x := types.NewFieldType(mysql.TypeString)
-			x.Flen = yyS[yypt-0].item.(int)
+			x.Flen = yyS[yypt-0].item.(int64)
 			x.Charset = charset.CharsetBin
 			x.Collate = charset.CharsetBin
 			x.Flag |= mysql.BinaryFlag
@@ -11990,7 +11990,7 @@ yynewstate:
 	case 1292:
 		{
 			x := types.NewFieldType(mysql.TypeVarchar)
-			x.Flen = yyS[yypt-0].item.(int)
+			x.Flen = yyS[yypt-0].item.(int64)
 			x.Charset = charset.CharsetBin
 			x.Collate = charset.CharsetBin
 			x.Flag |= mysql.BinaryFlag
@@ -12046,7 +12046,7 @@ yynewstate:
 	case 1304:
 		{
 			x := types.NewFieldType(mysql.TypeBlob)
-			x.Flen = yyS[yypt-0].item.(int)
+			x.Flen = yyS[yypt-0].item.(int64)
 			parser.yyVAL.item = x
 		}
 	case 1305:
@@ -12068,7 +12068,7 @@ yynewstate:
 	case 1308:
 		{
 			x := types.NewFieldType(mysql.TypeBlob)
-			x.Flen = yyS[yypt-0].item.(int)
+			x.Flen = yyS[yypt-0].item.(int64)
 			parser.yyVAL.item = x
 		}
 	case 1309:
@@ -12095,9 +12095,9 @@ yynewstate:
 		{
 			x := types.NewFieldType(mysql.TypeDatetime)
 			x.Flen = mysql.MaxDatetimeWidthNoFsp
-			x.Decimal = yyS[yypt-0].item.(int)
+			x.Decimal = yyS[yypt-0].item.(int64)
 			if x.Decimal > 0 {
-				x.Flen = x.Flen + 1 + x.Decimal
+				x.Flen = x.Flen + 1 + int64(x.Decimal)
 			}
 			parser.yyVAL.item = x
 		}
@@ -12105,9 +12105,9 @@ yynewstate:
 		{
 			x := types.NewFieldType(mysql.TypeTimestamp)
 			x.Flen = mysql.MaxDatetimeWidthNoFsp
-			x.Decimal = yyS[yypt-0].item.(int)
+			x.Decimal = yyS[yypt-0].item.(int64)
 			if x.Decimal > 0 {
-				x.Flen = x.Flen + 1 + x.Decimal
+				x.Flen = x.Flen + 1 + int64(x.Decimal)
 			}
 			parser.yyVAL.item = x
 		}
@@ -12115,16 +12115,16 @@ yynewstate:
 		{
 			x := types.NewFieldType(mysql.TypeDuration)
 			x.Flen = mysql.MaxDurationWidthNoFsp
-			x.Decimal = yyS[yypt-0].item.(int)
+			x.Decimal = yyS[yypt-0].item.(int64)
 			if x.Decimal > 0 {
-				x.Flen = x.Flen + 1 + x.Decimal
+				x.Flen = x.Flen + 1 + int64(x.Decimal)
 			}
 			parser.yyVAL.item = x
 		}
 	case 1316:
 		{
 			x := types.NewFieldType(mysql.TypeYear)
-			x.Flen = yyS[yypt-1].item.(int)
+			x.Flen = yyS[yypt-1].item.(int64)
 			if x.Flen != types.UnspecifiedLength && x.Flen != 4 {
 				yylex.Errorf("Supports only YEAR or YEAR(4) column.")
 				return -1
@@ -12169,7 +12169,7 @@ yynewstate:
 		}
 	case 1326:
 		{
-			parser.yyVAL.item = &ast.FloatOpt{Flen: yyS[yypt-0].item.(int), Decimal: types.UnspecifiedLength}
+			parser.yyVAL.item = &ast.FloatOpt{Flen: yyS[yypt-0].item.(int64), Decimal: types.UnspecifiedLength}
 		}
 	case 1327:
 		{
@@ -12177,7 +12177,7 @@ yynewstate:
 		}
 	case 1328:
 		{
-			parser.yyVAL.item = &ast.FloatOpt{Flen: int(yyS[yypt-3].item.(uint64)), Decimal: int(yyS[yypt-1].item.(uint64))}
+			parser.yyVAL.item = &ast.FloatOpt{Flen: int64(yyS[yypt-3].item.(uint64)), Decimal: int64(yyS[yypt-1].item.(uint64))}
 		}
 	case 1329:
 		{

--- a/parser.y
+++ b/parser.y
@@ -4244,7 +4244,7 @@ CastType:
 	"BINARY" OptFieldLen
 	{
 		x := types.NewFieldType(mysql.TypeVarString)
-		x.Flen = $2.(int)  // TODO: Flen should be the flen of expression
+		x.Flen = $2.(int64)  // TODO: Flen should be the flen of expression
 		if x.Flen != types.UnspecifiedLength {
 			x.Tp = mysql.TypeString
 		}
@@ -4256,7 +4256,7 @@ CastType:
 |	"CHAR" OptFieldLen OptBinary
 	{
 		x := types.NewFieldType(mysql.TypeVarString)
-		x.Flen = $2.(int)  // TODO: Flen should be the flen of expression
+		x.Flen = $2.(int64)  // TODO: Flen should be the flen of expression
 		x.Charset = $3.(*ast.OptBinary).Charset
 		if $3.(*ast.OptBinary).IsBinary{
 			x.Flag |= mysql.BinaryFlag
@@ -4279,9 +4279,9 @@ CastType:
 	{
 		x := types.NewFieldType(mysql.TypeDatetime)
 		x.Flen, _ = mysql.GetDefaultFieldLengthAndDecimalForCast(mysql.TypeDatetime)
-		x.Decimal = $2.(int)
+		x.Decimal = $2.(int64)
 		if x.Decimal > 0 {
-			x.Flen = x.Flen + 1 + x.Decimal
+			x.Flen = x.Flen + 1 + int64(x.Decimal)
 		}
 		x.Charset = charset.CharsetBin
 		x.Collate = charset.CollationBin
@@ -4303,9 +4303,9 @@ CastType:
 	{
 		x := types.NewFieldType(mysql.TypeDuration)
 		x.Flen, _ = mysql.GetDefaultFieldLengthAndDecimalForCast(mysql.TypeDuration)
-		x.Decimal = $2.(int)
+		x.Decimal = $2.(int64)
 		if x.Decimal > 0 {
-			x.Flen = x.Flen + 1 + x.Decimal
+			x.Flen = x.Flen + 1 + int64(x.Decimal)
 		}
 		x.Charset = charset.CharsetBin
 		x.Collate = charset.CollationBin
@@ -6638,7 +6638,7 @@ NumericType:
 	{
 		// TODO: check flen 0
 		x := types.NewFieldType($1.(byte))
-		x.Flen = $2.(int)
+		x.Flen = $2.(int64)
 		for _, o := range $3.([]*ast.TypeOpt) {
 			if o.IsUnsigned {
 				x.Flag |= mysql.UnsignedFlag
@@ -6704,7 +6704,7 @@ NumericType:
 |	BitValueType OptFieldLen
 	{
 		x := types.NewFieldType($1.(byte))
-		x.Flen = $2.(int)
+		x.Flen = $2.(int64)
 		if x.Flen == types.UnspecifiedLength || x.Flen == 0 {
 			x.Flen = 1
 		} else if x.Flen > 64 {
@@ -6817,7 +6817,7 @@ StringType:
 	NationalOpt "CHAR" FieldLen OptBinary OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeString)
-		x.Flen = $3.(int)
+		x.Flen = $3.(int64)
 		x.Charset = $4.(*ast.OptBinary).Charset
 		x.Collate = $5.(string)
 		if $4.(*ast.OptBinary).IsBinary {
@@ -6838,7 +6838,7 @@ StringType:
 |	"NATIONAL" "CHARACTER" FieldLen OptBinary OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeString)
-		x.Flen = $3.(int)
+		x.Flen = $3.(int64)
 		x.Charset = $4.(*ast.OptBinary).Charset
 		x.Collate = $5.(string)
 		if $4.(*ast.OptBinary).IsBinary {
@@ -6849,7 +6849,7 @@ StringType:
 |	Varchar FieldLen OptBinary OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeVarchar)
-		x.Flen = $2.(int)
+		x.Flen = $2.(int64)
 		x.Charset = $3.(*ast.OptBinary).Charset
 		x.Collate = $4.(string)
 		if $3.(*ast.OptBinary).IsBinary {
@@ -6860,7 +6860,7 @@ StringType:
 |	"BINARY" OptFieldLen
 	{
 		x := types.NewFieldType(mysql.TypeString)
-		x.Flen = $2.(int)
+		x.Flen = $2.(int64)
 		x.Charset = charset.CharsetBin
 		x.Collate = charset.CharsetBin
 		x.Flag |= mysql.BinaryFlag
@@ -6869,7 +6869,7 @@ StringType:
 |	"VARBINARY" FieldLen
 	{
 		x := types.NewFieldType(mysql.TypeVarchar)
-		x.Flen = $2.(int)
+		x.Flen = $2.(int64)
 		x.Charset = charset.CharsetBin
 		x.Collate = charset.CharsetBin
 		x.Flag |= mysql.BinaryFlag
@@ -6937,7 +6937,7 @@ BlobType:
 |	"BLOB" OptFieldLen
 	{
 		x := types.NewFieldType(mysql.TypeBlob)
-		x.Flen = $2.(int)
+		x.Flen = $2.(int64)
 		$$ = x
 	}
 |	"MEDIUMBLOB"
@@ -6961,7 +6961,7 @@ TextType:
 |	"TEXT" OptFieldLen
 	{
 		x := types.NewFieldType(mysql.TypeBlob)
-		x.Flen = $2.(int)
+		x.Flen = $2.(int64)
 		$$ = x
 	}
 |	"MEDIUMTEXT"
@@ -6991,9 +6991,9 @@ DateAndTimeType:
 	{
 		x := types.NewFieldType(mysql.TypeDatetime)
 		x.Flen = mysql.MaxDatetimeWidthNoFsp
-		x.Decimal = $2.(int)
+		x.Decimal = $2.(int64)
 		if x.Decimal > 0 {
-			x.Flen = x.Flen + 1 + x.Decimal
+			x.Flen = x.Flen + 1 + int64(x.Decimal)
 		}
 		$$ = x
 	}
@@ -7001,9 +7001,9 @@ DateAndTimeType:
 	{
 		x := types.NewFieldType(mysql.TypeTimestamp)
 		x.Flen = mysql.MaxDatetimeWidthNoFsp
-		x.Decimal = $2.(int)
+		x.Decimal = $2.(int64)
 		if x.Decimal > 0 {
-			x.Flen = x.Flen + 1 + x.Decimal
+			x.Flen = x.Flen + 1 + int64(x.Decimal)
 		}
 		$$ = x
 	}
@@ -7011,16 +7011,16 @@ DateAndTimeType:
 	{
 		x := types.NewFieldType(mysql.TypeDuration)
 		x.Flen = mysql.MaxDurationWidthNoFsp
-		x.Decimal = $2.(int)
+		x.Decimal = $2.(int64)
 		if x.Decimal > 0 {
-			x.Flen = x.Flen + 1 + x.Decimal
+			x.Flen = x.Flen + 1 + int64(x.Decimal)
 		}
 		$$ = x
 	}
 |	"YEAR" OptFieldLen FieldOpts
 	{
 		x := types.NewFieldType(mysql.TypeYear)
-		x.Flen = $2.(int)
+		x.Flen = $2.(int64)
 		if x.Flen != types.UnspecifiedLength && x.Flen != 4 {
 			yylex.Errorf("Supports only YEAR or YEAR(4) column.")
 			return -1
@@ -7072,7 +7072,7 @@ FloatOpt:
 	}
 |	FieldLen
 	{
-		$$ = &ast.FloatOpt{Flen: $1.(int), Decimal: types.UnspecifiedLength}
+		$$ = &ast.FloatOpt{Flen: $1.(int64), Decimal: types.UnspecifiedLength}
 	}
 |	Precision
 	{
@@ -7082,7 +7082,7 @@ FloatOpt:
 Precision:
 	'(' LengthNum ',' LengthNum ')'
 	{
-		$$ = &ast.FloatOpt{Flen: int($2.(uint64)), Decimal: int($4.(uint64))}
+		$$ = &ast.FloatOpt{Flen: int64($2.(uint64)), Decimal: int64($4.(uint64))}
 	}
 
 OptBinMod:

--- a/types/etc.go
+++ b/types/etc.go
@@ -95,7 +95,7 @@ func TypeToStr(tp byte, cs string) (r string) {
 }
 
 var (
-	dig2bytes = [10]int{0, 1, 1, 2, 2, 3, 3, 4, 4, 4}
+	dig2bytes = [10]int64{0, 1, 1, 2, 2, 3, 3, 4, 4, 4}
 )
 
 // constant values.

--- a/types/field_type.go
+++ b/types/field_type.go
@@ -32,8 +32,8 @@ const (
 type FieldType struct {
 	Tp      byte
 	Flag    uint
-	Flen    int
-	Decimal int
+	Flen    int64
+	Decimal int64
 	Charset string
 	Collate string
 	// Elems is the element list for enum and set type.
@@ -302,7 +302,7 @@ func (ft *FieldType) FormatAsCastType(w io.Writer) {
 const VarStorageLen = -1
 
 // StorageLength is the length of stored value for the type.
-func (ft *FieldType) StorageLength() int {
+func (ft *FieldType) StorageLength() int64 {
 	switch ft.Tp {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong,
 		mysql.TypeLonglong, mysql.TypeDouble, mysql.TypeFloat, mysql.TypeYear, mysql.TypeDuration,
@@ -311,7 +311,7 @@ func (ft *FieldType) StorageLength() int {
 		// This may not be the accurate length, because we may encode them as varint.
 		return 8
 	case mysql.TypeNewDecimal:
-		precision, frac := ft.Flen-ft.Decimal, ft.Decimal
+		precision, frac := ft.Flen-int64(ft.Decimal), int64(ft.Decimal)
 		return precision/digitsPerWord*wordSize + dig2bytes[precision%digitsPerWord] + frac/digitsPerWord*wordSize + dig2bytes[frac%digitsPerWord]
 	default:
 		return VarStorageLen


### PR DESCRIPTION
### What problem does this PR solve?
Fix Int overflow when build on 32 bit(https://github.com/pingcap/tidb/issues/3227)

### What is changed and how it works?
Explicit use of int64 instead of int
