### PR TITLE
parser: fix lexer that treat 9eTSs as a float

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -662,8 +662,8 @@ func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
 		case ch1 == '.':
 			return s.scanFloat(&pos)
 		case ch1 == 'B':
-			tok = unicode.ReplacementChar
-			return
+			s.r.incAsLongAs(isIdentChar)
+			return identifier, pos, s.r.data(&pos)
 		}
 	}
 

--- a/lexer.go
+++ b/lexer.go
@@ -639,11 +639,25 @@ func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
 			s.scanOct()
 		case ch1 == 'x' || ch1 == 'X':
 			s.r.inc()
+			p1 := s.r.pos()
 			s.scanHex()
+			p2 := s.r.pos()
+			// 0x, 0x7fz3 are identifier
+			if p1 == p2 || isDigit(s.r.peek()) {
+				s.r.incAsLongAs(isIdentChar)
+				return identifier, pos, s.r.data(&pos)
+			}
 			tok = hexLit
 		case ch1 == 'b':
 			s.r.inc()
+			p1 := s.r.pos()
 			s.scanBit()
+			p2 := s.r.pos()
+			// 0b, 0b123, 0b1ab are identifier
+			if p1 == p2 || isDigit(s.r.peek()) {
+				s.r.incAsLongAs(isIdentChar)
+				return identifier, pos, s.r.data(&pos)
+			}
 			tok = bitLit
 		case ch1 == '.':
 			return s.scanFloat(&pos)
@@ -656,13 +670,7 @@ func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
 	s.scanDigits()
 	ch0 = s.r.peek()
 	if ch0 == '.' || ch0 == 'e' || ch0 == 'E' {
-		s.r.inc()
-		ch1 := s.r.peek()
-		if isDigit(ch1) || ch1 == '+' || ch1 == '-' {
-			return s.scanFloat(&pos)
-		}
-		// 9eTSs is an identifier rather than number, fall through.
-		tok = identifier
+		return s.scanFloat(&pos)
 	}
 
 	// Identifiers may begin with a digit but unless quoted may not consist solely of digits.
@@ -723,11 +731,17 @@ func (s *Scanner) scanFloat(beg *Pos) (tok int, pos Pos, lit string) {
 	if ch0 == 'e' || ch0 == 'E' {
 		s.r.inc()
 		ch0 = s.r.peek()
-		if ch0 == '-' || ch0 == '+' {
+		if ch0 == '-' || ch0 == '+' || isDigit(ch0) {
 			s.r.inc()
+			s.scanDigits()
+			tok = floatLit
+		} else {
+			// D1 . D2 e XX when XX is not D3, parse the result to an identifier.
+			// 9e9e = 9e9(float) + e(identifier)
+			// 9est = 9est(identifier)
+			s.r.incAsLongAs(isIdentChar)
+			tok = identifier
 		}
-		s.scanDigits()
-		tok = floatLit
 	} else {
 		tok = decLit
 	}

--- a/lexer.go
+++ b/lexer.go
@@ -656,7 +656,13 @@ func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
 	s.scanDigits()
 	ch0 = s.r.peek()
 	if ch0 == '.' || ch0 == 'e' || ch0 == 'E' {
-		return s.scanFloat(&pos)
+		s.r.inc()
+		ch1 := s.r.peek()
+		if isDigit(ch1) || ch1 == '+' || ch1 == '-' {
+			return s.scanFloat(&pos)
+		}
+		// 9eTSs is an identifier rather than number, fall through.
+		tok = identifier
 	}
 
 	// Identifiers may begin with a digit but unless quoted may not consist solely of digits.

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -113,6 +113,7 @@ func (s *testLexerSuite) TestLiteral(c *C) {
 		{"132.313", decLit},
 		{"132.3e231", floatLit},
 		{"132.3e-231", floatLit},
+		{"001e-12", floatLit},
 		{"23416", intLit},
 		{"123test", identifier},
 		{"123" + string(unicode.ReplacementChar) + "xxx", identifier},
@@ -232,6 +233,8 @@ func (s *testLexerSuite) TestIdentifier(c *C) {
 		{"1_x", "1_x"},
 		{"0_x", "0_x"},
 		{replacementString, replacementString},
+		{"9e", "9e"},
+		{"9eTSs", "9eTSs"},
 		{fmt.Sprintf("t1%cxxx", 0), "t1"},
 	}
 	l := &Scanner{}

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -127,7 +127,7 @@ func (s *testLexerSuite) TestLiteral(c *C) {
 		{"\\N", null},
 		{".*", int('.')},       // `.`, `*`
 		{".1_t_1_x", int('.')}, // `.`, `1_t_1_x`
-		{"9e9e", intLit},       // 9e9e = 9e9 + e
+		{"9e9e", floatLit},     // 9e9e = 9e9 + e
 		// Issue #3954
 		{".1e23", floatLit}, // `.1e23`
 		{".123", decLit},    // `.123`
@@ -235,6 +235,12 @@ func (s *testLexerSuite) TestIdentifier(c *C) {
 		{"0_x", "0_x"},
 		{replacementString, replacementString},
 		{"9e", "9e"},
+		{"0b", "0b"},
+		{"0b123", "0b123"},
+		{"0b1ab", "0b1ab"},
+		{"0x", "0x"},
+		{"0x7fz3", "0x7fz3"},
+		{"023a4", "023a4"},
 		{"9eTSs", "9eTSs"},
 		{fmt.Sprintf("t1%cxxx", 0), "t1"},
 	}

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -238,6 +238,7 @@ func (s *testLexerSuite) TestIdentifier(c *C) {
 		{"0b", "0b"},
 		{"0b123", "0b123"},
 		{"0b1ab", "0b1ab"},
+		{"0B01", "0B01"},
 		{"0x", "0x"},
 		{"0x7fz3", "0x7fz3"},
 		{"023a4", "023a4"},

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -127,6 +127,7 @@ func (s *testLexerSuite) TestLiteral(c *C) {
 		{"\\N", null},
 		{".*", int('.')},       // `.`, `*`
 		{".1_t_1_x", int('.')}, // `.`, `1_t_1_x`
+		{"9e9e", intLit},       // 9e9e = 9e9 + e
 		// Issue #3954
 		{".1e23", floatLit}, // `.1e23`
 		{".123", decLit},    // `.123`

--- a/parser_test.go
+++ b/parser_test.go
@@ -2039,8 +2039,9 @@ func (s *testParserSuite) TestType(c *C) {
 
 		// for bit
 		{"select 0b01, 0b0, b'11', B'11'", true, "SELECT b'1',b'0',b'11',b'11'"},
-		{"select 0B01", false, ""},
-		// {"select 0b21", false, ""}, 0b21 is an identifier, the statement could parse.
+		// 0B01 and 0b21 are identifiers, the following two statement could parse.
+		// {"select 0B01", false, ""},
+		// {"select 0b21", false, ""},
 
 		// for enum and set type
 		{"create table t (c1 enum('a', 'b'), c2 set('a', 'b'))", true, ""},

--- a/parser_test.go
+++ b/parser_test.go
@@ -2040,7 +2040,7 @@ func (s *testParserSuite) TestType(c *C) {
 		// for bit
 		{"select 0b01, 0b0, b'11', B'11'", true, "SELECT b'1',b'0',b'11',b'11'"},
 		{"select 0B01", false, ""},
-		{"select 0b21", false, ""},
+		// {"select 0b21", false, ""}, 0b21 is an identifier, the statement could parse.
 
 		// for enum and set type
 		{"create table t (c1 enum('a', 'b'), c2 set('a', 'b'))", true, ""},


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Scan 9eTSs should get an identifier token

### What is changed and how it works?

Fix https://github.com/pingcap/tidb/issues/8983

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

