### PR TITLE
model: view  add quote support

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -2173,7 +2173,7 @@ type WindowSpec struct {
 
 // Restore implements Node interface.
 func (n *WindowSpec) Restore(ctx *RestoreCtx) error {
-	if name := n.Name.String(); name != "" {
+	if name := n.Name.String(); name != "" && name != "<unnamed window>" {
 		ctx.WriteName(name)
 		if n.OnlyAlias {
 			return nil

--- a/model/model.go
+++ b/model/model.go
@@ -537,7 +537,18 @@ type ViewInfo struct {
 	Security    ViewSecurity       `json:"view_security"`
 	SelectStmt  string             `json:"view_select"`
 	CheckOption ViewCheckOption    `json:"view_checkoption"`
-	Cols        []CIStr            `json:"view_cols"`
+	//todo Remove this attribute when upgrade to next release version
+	Cols            []CIStr `json:"view_cols"`
+	SelectStmtQuote string  `json:view_select_quote`
+}
+
+// SelectStmtByQuote provide SelectStmt with different quote
+func (v ViewInfo) SelectStmtBySQLMode(mode mysql.SQLMode) string {
+	if mode.HasANSIQuotesMode() {
+		return v.SelectStmtQuote
+	} else {
+		return v.SelectStmt
+	}
 }
 
 // PartitionType is the type for PartitionInfo

--- a/model/model.go
+++ b/model/model.go
@@ -537,7 +537,7 @@ type ViewInfo struct {
 	Security    ViewSecurity       `json:"view_security"`
 	SelectStmt  string             `json:"view_select"`
 	CheckOption ViewCheckOption    `json:"view_checkoption"`
-	//todo Remove this attribute when upgrade to next release version
+	// TODO: Remove this attribute when upgrade to next release version
 	Cols            []CIStr `json:"view_cols"`
 	SelectStmtQuote string  `json:view_select_quote`
 }

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -80,6 +80,21 @@ func (*testModelSuite) TestModelBasic(c *C) {
 		PKIsHandle:  true,
 	}
 
+	view := &TableInfo{
+		ID:          1,
+		Name:        NewCIStr("v"),
+		Charset:     "utf8",
+		Collate:     "utf8_bin",
+		Columns:     []*ColumnInfo{column},
+		Indices:     nil,
+		ForeignKeys: nil,
+		PKIsHandle:  true,
+		View: &ViewInfo{
+			SelectStmt:      "SELECT 1 AS `C` FROM `DUAL`",
+			SelectStmtQuote: "SELECT 1 AS \"C\" FROM \"DUAL\"",
+		},
+	}
+
 	dbInfo := &DBInfo{
 		ID:      1,
 		Name:    NewCIStr("test"),
@@ -124,6 +139,9 @@ func (*testModelSuite) TestModelBasic(c *C) {
 	}
 	no := anIndex.HasPrefixIndex()
 	c.Assert(no, Equals, false)
+
+	c.Assert(view.View.SelectStmtBySQLMode(mysql.ModeNone), Equals, "SELECT 1 AS `C` FROM `DUAL`")
+	c.Assert(view.View.SelectStmtBySQLMode(mysql.ModeANSIQuotes), Equals, "SELECT 1 AS \"C\" FROM \"DUAL\"")
 }
 
 func (*testModelSuite) TestJobStartTime(c *C) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Store two version stmt in View's metadata and use `func (v ViewInfo) SelectStmtByQuote(quote string) string` to obtain `Quote Stmt String`.

### What is changed and how it works?
Change `SelectStmt` from `String` to `Array String`.

### Check List 

Tests 

 - Unit test (in TiDB)