### PR TITLE
parser: fix stored option in generated column restore

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -407,6 +407,11 @@ func (n *ColumnOption) Restore(ctx *RestoreCtx) error {
 			return errors.Annotate(err, "An error occurred while splicing ColumnOption GENERATED ALWAYS Expr")
 		}
 		ctx.WritePlain(")")
+		if n.Stored {
+			ctx.WritePlain(" STORED")
+		} else {
+			ctx.WritePlain(" VIRTUAL")
+		}
 	case ColumnOptionReference:
 		if err := n.Refer.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while splicing ColumnOption ReferenceDef")

--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -408,9 +408,9 @@ func (n *ColumnOption) Restore(ctx *RestoreCtx) error {
 		}
 		ctx.WritePlain(")")
 		if n.Stored {
-			ctx.WritePlain(" STORED")
+			ctx.WriteKeyWord(" STORED")
 		} else {
-			ctx.WritePlain(" VIRTUAL")
+			ctx.WriteKeyWord(" VIRTUAL")
 		}
 	case ColumnOptionReference:
 		if err := n.Refer.Restore(ctx); err != nil {

--- a/ast/ddl_test.go
+++ b/ast/ddl_test.go
@@ -186,7 +186,9 @@ func (ts *testDDLSuite) TestDDLColumnOptionRestore(c *C) {
 		{"UNIQUE KEY", "UNIQUE KEY"},
 		{"on update CURRENT_TIMESTAMP", "ON UPDATE CURRENT_TIMESTAMP()"},
 		{"comment 'hello'", "COMMENT 'hello'"},
-		{"generated always as(id + 1)", "GENERATED ALWAYS AS(`id`+1)"},
+		{"generated always as(id + 1)", "GENERATED ALWAYS AS(`id`+1) VIRTUAL"},
+		{"generated always as(id + 1) virtual", "GENERATED ALWAYS AS(`id`+1) VIRTUAL"},
+		{"generated always as(id + 1) stored", "GENERATED ALWAYS AS(`id`+1) STORED"},
 		{"REFERENCES parent(id)", "REFERENCES `parent`(`id`)"},
 	}
 	extractNodeFunc := func(node Node) Node {
@@ -248,7 +250,7 @@ func (ts *testDDLSuite) TestDDLColumnDefRestore(c *C) {
 		{"id INT(11) UNIQUE KEY", "`id` INT(11) UNIQUE KEY"},
 		{"id INT(11) on update CURRENT_TIMESTAMP", "`id` INT(11) ON UPDATE CURRENT_TIMESTAMP()"},
 		{"id INT(11) comment 'hello'", "`id` INT(11) COMMENT 'hello'"},
-		{"id INT(11) generated always as(id + 1)", "`id` INT(11) GENERATED ALWAYS AS(`id`+1)"},
+		{"id INT(11) generated always as(id + 1)", "`id` INT(11) GENERATED ALWAYS AS(`id`+1) VIRTUAL"},
 		{"id INT(11) REFERENCES parent(id)", "`id` INT(11) REFERENCES `parent`(`id`)"},
 	}
 	extractNodeFunc := func(node Node) Node {

--- a/go.mod1
+++ b/go.mod1
@@ -11,6 +11,7 @@ require (
 	github.com/pingcap/errors v0.11.0
 	github.com/pingcap/tidb v0.0.0-20190218065808-69472bd1a6e9
 	github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
 )

--- a/go.mod1
+++ b/go.mod1
@@ -11,7 +11,6 @@ require (
 	github.com/pingcap/errors v0.11.0
 	github.com/pingcap/tidb v0.0.0-20190218065808-69472bd1a6e9
 	github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7
-	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
 )

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pingcap/errors"
 	. "github.com/pingcap/parser/format"
-	"github.com/pkg/errors"
 )
 
 func newInvalidModeErr(s string) error {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`STORED` option for generated column is missing after `Restore`

### What is changed and how it works?
- output `STORED` or `VIRTUAL` based on the `Stored` field of column option.
- fix errors lib introduced in commit https://github.com/pingcap/parser/commit/60fd134cfde20424ba588c785debb3be0a086210

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

