### PR TITLE
auth: use safe String() for UserIdentity

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -55,6 +55,9 @@ func (user *UserIdentity) Restore(ctx *RestoreCtx) error {
 // String converts UserIdentity to the format user@host.
 func (user *UserIdentity) String() string {
 	// TODO: Escape username and hostname.
+	if user == nil {
+		return ""
+	}
 	return fmt.Sprintf("%s@%s", user.Username, user.Hostname)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In some test cases, `SessionVars.User` is nil when it is used.

### What is changed and how it works?
Check if it is nil in its `String()`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch
