### PR TITLE
mysql: change MySQL version from 5.7.10 to 5.7.25

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -31,7 +31,7 @@ var (
 	TiDBReleaseVersion = "None"
 
 	// ServerVersion is the version information of this tidb-server in MySQL's format.
-	ServerVersion = fmt.Sprintf("5.7.10-TiDB-%s", TiDBReleaseVersion)
+	ServerVersion = fmt.Sprintf("5.7.25-TiDB-%s", TiDBReleaseVersion)
 )
 
 // Header information.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
change MySQL version from 5.7.10 to 5.7.25

related PR: 
https://github.com/pingcap/tidb/pull/9553

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
release-2.1
