### PR TITLE
executor: add `DROP ROLE` support

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -887,13 +887,18 @@ func (n *AlterUserStmt) Accept(v Visitor) (Node, bool) {
 type DropUserStmt struct {
 	stmtNode
 
-	IfExists bool
-	UserList []*auth.UserIdentity
+	IfExists   bool
+	IsDropRole bool
+	UserList   []*auth.UserIdentity
 }
 
 // Restore implements Node interface.
 func (n *DropUserStmt) Restore(ctx *RestoreCtx) error {
-	ctx.WriteKeyWord("DROP USER ")
+	if n.IsDropRole {
+		ctx.WriteKeyWord("DROP ROLE ")
+	} else {
+		ctx.WriteKeyWord("DROP USER ")
+	}
 	if n.IfExists {
 		ctx.WriteKeyWord("IF EXISTS ")
 	}

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -182,6 +182,10 @@ const (
 	GlobalStatusTable = "GLOBAL_STATUS"
 	// TiDBTable is the table contains tidb info.
 	TiDBTable = "tidb"
+	//  RoleEdgesTable is the table contains role relation info
+	RoleEdgeTable = "role_edges"
+	// DefaultRoleTable is the table contain default active role info
+	DefaultRoleTable = "default_roles"
 )
 
 // PrivilegeType  privilege

--- a/parser.go
+++ b/parser.go
@@ -8438,11 +8438,29 @@ yynewstate:
 		}
 	case 233:
 		{
-			parser.yyVAL.statement = &ast.DropUserStmt{IfExists: false, UserList: yyS[yypt-0].item.([]*auth.UserIdentity)}
+			parser.yyVAL.statement = &ast.DropUserStmt{IsDropRole: false, IfExists: false, UserList: yyS[yypt-0].item.([]*auth.UserIdentity)}
 		}
 	case 234:
 		{
-			parser.yyVAL.statement = &ast.DropUserStmt{IfExists: true, UserList: yyS[yypt-0].item.([]*auth.UserIdentity)}
+			parser.yyVAL.statement = &ast.DropUserStmt{IsDropRole: false, IfExists: true, UserList: yyS[yypt-0].item.([]*auth.UserIdentity)}
+		}
+	case 235:
+		{
+			tmp := make([]*auth.UserIdentity, 0, 10)
+			roleList := yyS[yypt-0].item.([]*auth.RoleIdentity)
+			for _, r := range roleList {
+				tmp = append(tmp, &auth.UserIdentity{Username: r.Username, Hostname: r.Hostname})
+			}
+			parser.yyVAL.statement = &ast.DropUserStmt{IsDropRole: true, IfExists: false, UserList: tmp}
+		}
+	case 236:
+		{
+			tmp := make([]*auth.UserIdentity, 0, 10)
+			roleList := yyS[yypt-0].item.([]*auth.RoleIdentity)
+			for _, r := range roleList {
+				tmp = append(tmp, &auth.UserIdentity{Username: r.Username, Hostname: r.Hostname})
+			}
+			parser.yyVAL.statement = &ast.DropUserStmt{IsDropRole: true, IfExists: true, UserList: tmp}
 		}
 	case 237:
 		{

--- a/parser.y
+++ b/parser.y
@@ -2429,19 +2429,31 @@ DropViewStmt:
 DropUserStmt:
 	"DROP" "USER" UsernameList
 	{
-		$$ = &ast.DropUserStmt{IfExists: false, UserList: $3.([]*auth.UserIdentity)}
+		$$ = &ast.DropUserStmt{IsDropRole: false, IfExists: false, UserList: $3.([]*auth.UserIdentity)}
 	}
 |	"DROP" "USER" "IF" "EXISTS" UsernameList
 	{
-		$$ = &ast.DropUserStmt{IfExists: true, UserList: $5.([]*auth.UserIdentity)}
+		$$ = &ast.DropUserStmt{IsDropRole: false, IfExists: true, UserList: $5.([]*auth.UserIdentity)}
 	}
 
 DropRoleStmt:
 	"DROP" "ROLE" RolenameList
 	{
+		tmp := make([]*auth.UserIdentity, 0, 10)
+		roleList := $3.([]*auth.RoleIdentity)
+		for _, r := range roleList {
+			tmp = append(tmp, &auth.UserIdentity{Username:r.Username, Hostname: r.Hostname})
+		}
+		$$ = &ast.DropUserStmt{IsDropRole: true, IfExists: false, UserList: tmp}
 	}
 |	"DROP" "ROLE" "IF" "EXISTS" RolenameList
 	{
+		tmp := make([]*auth.UserIdentity, 0, 10)
+		roleList := $5.([]*auth.RoleIdentity)
+		for _, r := range roleList {
+			tmp = append(tmp, &auth.UserIdentity{Username:r.Username, Hostname: r.Hostname})
+		}
+		$$ = &ast.DropUserStmt{IsDropRole: true, IfExists: true, UserList: tmp}
 	}
 
 DropStatsStmt:

--- a/parser_test.go
+++ b/parser_test.go
@@ -2114,9 +2114,9 @@ func (s *testParserSuite) TestPrivilege(c *C) {
 		{`ALTER USER IF EXISTS USER() IDENTIFIED BY 'new-password'`, true, "ALTER USER IF EXISTS USER() IDENTIFIED BY 'new-password'"},
 		{`DROP USER 'root'@'localhost', 'root1'@'localhost'`, true, "DROP USER `root`@`localhost`, `root1`@`localhost`"},
 		{`DROP USER IF EXISTS 'root'@'localhost'`, true, "DROP USER IF EXISTS `root`@`localhost`"},
-		{`DROP ROLE 'role'@'localhost', 'role1'@'localhost'`, true, ""},
-		{`DROP ROLE 'administrator', 'developer';`, true, ""},
-		{`DROP ROLE IF EXISTS 'role'@'localhost'`, true, ""},
+		{`DROP ROLE 'role'@'localhost', 'role1'@'localhost'`, true, "DROP ROLE `role`@`localhost`, `role1`@`localhost`"},
+		{`DROP ROLE 'administrator', 'developer';`, true, "DROP ROLE `administrator`@`%`, `developer`@`%`"},
+		{`DROP ROLE IF EXISTS 'role'@'localhost'`, true, "DROP ROLE IF EXISTS `role`@`localhost`"},
 
 		// for grant statement
 		{"GRANT ALL ON db1.* TO 'jeffrey'@'localhost';", true, "GRANT ALL ON `db1`.* TO `jeffrey`@`localhost`"},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
add `DROP ROLE` function for parser and executor.

### What is changed and how it works?
Role is same as user, is store in `mysql.user` table. We do same action as `DROP USER` when we need to drop a role. Also, as we has added some system table for RBAC, like `mysql.role_edges` and 
 `mysql.default_role`. We have to delete information from these tables when execute `DROP ROLE`

tidb pr: https://github.com/pingcap/tidb/pull/9616

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported variable/fields change

Side effects

 - Increased code complexity

