### PR TITLE
parser: fix error message for illegal year type definition.

### DIFF
--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -833,7 +833,7 @@ var MySQLErrName = map[uint16]string{
 	ErrInternal:                                              "Internal : %s",
 	ErrInnodbImport:                                          "ALTER TABLE '%-.192s' IMPORT TABLESPACE failed with error %d : '%s'",
 	ErrInnodbIndexCorrupt:                                    "Index corrupt: %s",
-	ErrInvalidYearColumnLength:                               "YEAR(%d) column type is deprecated. Creating YEAR(4) column instead.",
+	ErrInvalidYearColumnLength:                               "Supports only YEAR or YEAR(4) column",
 	ErrNotValidPassword:                                      "Your password does not satisfy the current policy requirements",
 	ErrMustChangePassword:                                    "You must SET PASSWORD before executing this statement",
 	ErrFkNoIndexChild:                                        "Failed to add the foreign key constaint. Missing index for constraint '%s' in the foreign table '%s'",

--- a/parser.go
+++ b/parser.go
@@ -12611,7 +12611,7 @@ yynewstate:
 			x := types.NewFieldType(mysql.TypeYear)
 			x.Flen = yyS[yypt-1].item.(int)
 			if x.Flen != types.UnspecifiedLength && x.Flen != 4 {
-				yylex.AppendError(yylex.Errorf("Supports only YEAR or YEAR(4) column."))
+				yylex.AppendError(ErrInvalidYearColumnLength.GenWithStackByArgs())
 				return -1
 			}
 			parser.yyVAL.item = x

--- a/parser.y
+++ b/parser.y
@@ -7283,7 +7283,7 @@ DateAndTimeType:
 		x := types.NewFieldType(mysql.TypeYear)
 		x.Flen = $2.(int)
 		if x.Flen != types.UnspecifiedLength && x.Flen != 4 {
-			yylex.AppendError(yylex.Errorf("Supports only YEAR or YEAR(4) column."))
+			yylex.AppendError(ErrInvalidYearColumnLength.GenWithStackByArgs())
 			return -1
 		}
 		$$ = x

--- a/parser_test.go
+++ b/parser_test.go
@@ -2006,6 +2006,9 @@ func (s *testParserSuite) TestErrorMsg(c *C) {
 	c.Assert(err.Error(), Equals, "line 1 column 31 near \"t1.a = t2.a;\" ")
 	_, _, err = parser.Parse("select * from t1 join t2 on t1.a >>> t2.a;", "", "")
 	c.Assert(err.Error(), Equals, "line 1 column 36 near \"> t2.a;\" ")
+
+	_, _, err = parser.Parse("create table t(f_year year(5))ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;", "", "")
+	c.Assert(err.Error(), Equals, "[parser:1818]Supports only YEAR or YEAR(4) column")
 }
 
 func (s *testParserSuite) TestOptimizerHints(c *C) {

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	codeErrParse               = terror.ErrCode(mysql.ErrParse)
-	codeErrSyntax              = terror.ErrCode(mysql.ErrSyntax)
-	codeErrUnknownCharacterSet = terror.ErrCode(mysql.ErrUnknownCharacterSet)
+	codeErrParse                   = terror.ErrCode(mysql.ErrParse)
+	codeErrSyntax                  = terror.ErrCode(mysql.ErrSyntax)
+	codeErrUnknownCharacterSet     = terror.ErrCode(mysql.ErrUnknownCharacterSet)
+	codeErrInvalidYearColumnLength = terror.ErrCode(mysql.ErrInvalidYearColumnLength)
 )
 
 var (
@@ -39,6 +40,8 @@ var (
 	ErrParse = terror.ClassParser.New(codeErrParse, mysql.MySQLErrName[mysql.ErrParse])
 	// ErrUnknownCharacterSet returns for no character set found error.
 	ErrUnknownCharacterSet = terror.ClassParser.New(codeErrUnknownCharacterSet, mysql.MySQLErrName[mysql.ErrUnknownCharacterSet])
+	// ErrInvalidYearColumnLength returns for illegal column length for year type.
+	ErrInvalidYearColumnLength = terror.ClassParser.New(codeErrInvalidYearColumnLength, mysql.MySQLErrName[mysql.ErrInvalidYearColumnLength])
 	// SpecFieldPattern special result field pattern
 	SpecFieldPattern = regexp.MustCompile(`(\/\*!(M?[0-9]{5,6})?|\*\/)`)
 	specCodePattern  = regexp.MustCompile(`\/\*!(M?[0-9]{5,6})?([^*]|\*+[^*/])*\*+\/`)
@@ -48,9 +51,10 @@ var (
 
 func init() {
 	parserMySQLErrCodes := map[terror.ErrCode]uint16{
-		codeErrSyntax:              mysql.ErrSyntax,
-		codeErrParse:               mysql.ErrParse,
-		codeErrUnknownCharacterSet: mysql.ErrUnknownCharacterSet,
+		codeErrSyntax:                  mysql.ErrSyntax,
+		codeErrParse:                   mysql.ErrParse,
+		codeErrUnknownCharacterSet:     mysql.ErrUnknownCharacterSet,
+		codeErrInvalidYearColumnLength: mysql.ErrInvalidYearColumnLength,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassParser] = parserMySQLErrCodes
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When create table, if year type is not defined correctly, the error message is not consistent with MySQL for now. In MySQL:
```sql
mysql> create table t(f_year year(5))ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
ERROR 1818 (HY000): Supports only YEAR or YEAR(4) column.
```
While in TiDB:
```
tidb> create table t(f_year year(5))ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for th
e right syntax to use line 1 column 30 near ")ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"Supports only Y
EAR or YEAR(4) column.
```

### What is changed and how it works?
Return correct error type in parser.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes
