### PR TITLE
types: port 'HasCharset' function from MySQL

### DIFF
--- a/types/field_type.go
+++ b/types/field_type.go
@@ -324,7 +324,8 @@ func (ft *FieldType) StorageLength() int {
 // statements(like `SHOW CREATE TABLE`) from attaching a CHARACTER SET clause to the column.
 func HasCharset(ft *FieldType) bool {
 	switch ft.Tp {
-	case mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+	case mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeBlob,
+		mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
 		return !mysql.HasBinaryFlag(ft.Flag)
 	case mysql.TypeEnum, mysql.TypeSet:
 		return true

--- a/types/field_type.go
+++ b/types/field_type.go
@@ -319,3 +319,15 @@ func (ft *FieldType) StorageLength() int {
 		return VarStorageLen
 	}
 }
+
+// HasCharset indicates if a COLUMN has an associated charset. Returning false here prevents some information
+// statements(like `SHOW CREATE TABLE`) from attaching a CHARACTER SET clause to the column.
+func HasCharset(ft *FieldType) bool {
+	switch ft.Tp {
+	case mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		return !mysql.HasBinaryFlag(ft.Flag)
+	case mysql.TypeEnum, mysql.TypeSet:
+		return true
+	}
+	return false
+}

--- a/types/field_type_test.go
+++ b/types/field_type_test.go
@@ -11,14 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package types_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser"
+	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/mysql"
+	. "github.com/pingcap/parser/types"
+	_ "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/testleak"
 )
 
@@ -39,12 +44,14 @@ func (s *testFieldTypeSuite) TestFieldType(c *C) {
 	c.Assert(ft.Decimal, Equals, UnspecifiedLength)
 	ft.Decimal = 5
 	c.Assert(ft.String(), Equals, "time(5)")
+	c.Assert(HasCharset(ft), IsFalse)
 
 	ft = NewFieldType(mysql.TypeLong)
 	ft.Flen = 5
 	ft.Flag = mysql.UnsignedFlag | mysql.ZerofillFlag
 	c.Assert(ft.String(), Equals, "int(5) UNSIGNED ZEROFILL")
 	c.Assert(ft.InfoSchemaStr(), Equals, "int(5) unsigned")
+	c.Assert(HasCharset(ft), IsFalse)
 
 	ft = NewFieldType(mysql.TypeFloat)
 	ft.Flen = 12   // Default
@@ -62,6 +69,7 @@ func (s *testFieldTypeSuite) TestFieldType(c *C) {
 	ft.Flen = 7    // Not Default
 	ft.Decimal = 3 // Not Default
 	c.Assert(ft.String(), Equals, "float(7,3)")
+	c.Assert(HasCharset(ft), IsFalse)
 
 	ft = NewFieldType(mysql.TypeDouble)
 	ft.Flen = 22   // Default
@@ -79,88 +87,156 @@ func (s *testFieldTypeSuite) TestFieldType(c *C) {
 	ft.Flen = 7    // Not Default
 	ft.Decimal = 3 // Not Default
 	c.Assert(ft.String(), Equals, "double(7,3)")
+	c.Assert(HasCharset(ft), IsFalse)
 
 	ft = NewFieldType(mysql.TypeBlob)
 	ft.Flen = 10
 	ft.Charset = "UTF8"
 	ft.Collate = "UTF8_UNICODE_GI"
 	c.Assert(ft.String(), Equals, "text CHARACTER SET UTF8 COLLATE UTF8_UNICODE_GI")
+	c.Assert(HasCharset(ft), IsTrue)
 
 	ft = NewFieldType(mysql.TypeVarchar)
 	ft.Flen = 10
 	ft.Flag |= mysql.BinaryFlag
 	c.Assert(ft.String(), Equals, "varchar(10) BINARY")
+	c.Assert(HasCharset(ft), IsFalse)
 
 	ft = NewFieldType(mysql.TypeString)
 	ft.Charset = charset.CollationBin
 	ft.Flag |= mysql.BinaryFlag
 	c.Assert(ft.String(), Equals, "binary(1)")
+	c.Assert(HasCharset(ft), IsFalse)
 
 	ft = NewFieldType(mysql.TypeEnum)
 	ft.Elems = []string{"a", "b"}
 	c.Assert(ft.String(), Equals, "enum('a','b')")
+	c.Assert(HasCharset(ft), IsTrue)
 
 	ft = NewFieldType(mysql.TypeEnum)
 	ft.Elems = []string{"'a'", "'b'"}
 	c.Assert(ft.String(), Equals, "enum('''a''','''b''')")
+	c.Assert(HasCharset(ft), IsTrue)
 
 	ft = NewFieldType(mysql.TypeEnum)
 	ft.Elems = []string{"a\nb", "a\tb", "a\rb"}
 	c.Assert(ft.String(), Equals, "enum('a\\nb','a\tb','a\\rb')")
+	c.Assert(HasCharset(ft), IsTrue)
 
 	ft = NewFieldType(mysql.TypeEnum)
 	ft.Elems = []string{"a\nb", "a'\t\r\nb", "a\rb"}
 	c.Assert(ft.String(), Equals, "enum('a\\nb','a''	\\r\\nb','a\\rb')")
+	c.Assert(HasCharset(ft), IsTrue)
 
 	ft = NewFieldType(mysql.TypeSet)
 	ft.Elems = []string{"a", "b"}
 	c.Assert(ft.String(), Equals, "set('a','b')")
+	c.Assert(HasCharset(ft), IsTrue)
 
 	ft = NewFieldType(mysql.TypeSet)
 	ft.Elems = []string{"'a'", "'b'"}
 	c.Assert(ft.String(), Equals, "set('''a''','''b''')")
+	c.Assert(HasCharset(ft), IsTrue)
 
 	ft = NewFieldType(mysql.TypeSet)
 	ft.Elems = []string{"a\nb", "a'\t\r\nb", "a\rb"}
 	c.Assert(ft.String(), Equals, "set('a\\nb','a''	\\r\\nb','a\\rb')")
+	c.Assert(HasCharset(ft), IsTrue)
 
 	ft = NewFieldType(mysql.TypeSet)
 	ft.Elems = []string{"a'\nb", "a'b\tc"}
 	c.Assert(ft.String(), Equals, "set('a''\\nb','a''b	c')")
+	c.Assert(HasCharset(ft), IsTrue)
 
 	ft = NewFieldType(mysql.TypeTimestamp)
 	ft.Flen = 8
 	ft.Decimal = 2
 	c.Assert(ft.String(), Equals, "timestamp(2)")
+	c.Assert(HasCharset(ft), IsFalse)
 	ft = NewFieldType(mysql.TypeTimestamp)
 	ft.Flen = 8
 	ft.Decimal = 0
 	c.Assert(ft.String(), Equals, "timestamp")
+	c.Assert(HasCharset(ft), IsFalse)
 
 	ft = NewFieldType(mysql.TypeDatetime)
 	ft.Flen = 8
 	ft.Decimal = 2
 	c.Assert(ft.String(), Equals, "datetime(2)")
+	c.Assert(HasCharset(ft), IsFalse)
 	ft = NewFieldType(mysql.TypeDatetime)
 	ft.Flen = 8
 	ft.Decimal = 0
 	c.Assert(ft.String(), Equals, "datetime")
+	c.Assert(HasCharset(ft), IsFalse)
 
 	ft = NewFieldType(mysql.TypeDate)
 	ft.Flen = 8
 	ft.Decimal = 2
 	c.Assert(ft.String(), Equals, "date")
+	c.Assert(HasCharset(ft), IsFalse)
 	ft = NewFieldType(mysql.TypeDate)
 	ft.Flen = 8
 	ft.Decimal = 0
 	c.Assert(ft.String(), Equals, "date")
+	c.Assert(HasCharset(ft), IsFalse)
 
 	ft = NewFieldType(mysql.TypeYear)
 	ft.Flen = 4
 	ft.Decimal = 0
 	c.Assert(ft.String(), Equals, "year(4)")
+	c.Assert(HasCharset(ft), IsFalse)
 	ft = NewFieldType(mysql.TypeYear)
 	ft.Flen = 2
 	ft.Decimal = 2
 	c.Assert(ft.String(), Equals, "year(2)") // Note: Invalid year.
+	c.Assert(HasCharset(ft), IsFalse)
+}
+
+func (s *testFieldTypeSuite) TestHasCharsetFromStmt(c *C) {
+	template := "CREATE TABLE t(a %s)"
+
+	types := []struct {
+		strType    string
+		hasCharset bool
+	}{
+		{"int", false},
+		{"real", false},
+		{"float", false},
+		{"bit", false},
+		{"bool", false},
+		{"char(1)", true},
+		{"national char(1)", true},
+		{"binary", false},
+		{"varchar(1)", true},
+		{"national varchar(1)", true},
+		{"varbinary(1)", false},
+		{"year", false},
+		{"date", false},
+		{"time", false},
+		{"datetime", false},
+		{"timestamp", false},
+		{"blob", false},
+		{"tinyblob", false},
+		{"mediumblob", false},
+		{"longblob", false},
+		{"bit", false},
+		{"text", true},
+		{"tinytext", true},
+		{"mediumtext", true},
+		{"longtext", true},
+		{"json", false},
+		{"enum('1')", true},
+		{"set('1')", true},
+	}
+
+	p := parser.New()
+	for _, t := range types {
+		sql := fmt.Sprintf(template, t.strType)
+		stmt, err := p.ParseOneStmt(sql, "", "")
+		c.Assert(err, IsNil)
+
+		col := stmt.(*ast.CreateTableStmt).Cols[0]
+		c.Assert(HasCharset(col.Tp), Equals, t.hasCharset)
+	}
 }


### PR DESCRIPTION
### What problem does this PR solve?
This PR aims to solve the some known show charset/collation issues in TiDB, for example, https://github.com/pingcap/tidb/issues/9837

### What is changed and how it works?
A `HasCharset` function is ported from MySQL source, for example:

[Field::has_charset()](https://github.com/mysql/mysql-server/blob/3701bd36bec259fe494c75c9b30c57b01e598297/sql/field.h#L1417)

[Field_string::has_charset()](
 https://github.com/mysql/mysql-server/blob/3701bd36bec259fe494c75c9b30c57b01e598297/sql/field.h#L3541)

This function can be used in the procedure of some show-schema executions, for example, in MySQL it decides where a given column's `Collation` result is `NULL` in `show full columns` statement:

[sql_show.cc::store_column_type()](https://github.com/mysql/mysql-server/blob/3701bd36bec259fe494c75c9b30c57b01e598297/sql/sql_show.cc#L5303)

### Check List

Tests 

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch
