### PR TITLE
add drop view ddl action (#131)

### DIFF
--- a/model/ddl.go
+++ b/model/ddl.go
@@ -53,6 +53,7 @@ const (
 	ActionCreateView                   ActionType = 21
 	ActionModifyTableCharsetAndCollate ActionType = 22
 	ActionTruncateTablePartition       ActionType = 23
+	ActionDropView                     ActionType = 24
 )
 
 // AddIndexStr is a string related to the operation of "add index".
@@ -82,6 +83,7 @@ var actionMap = map[ActionType]string{
 	ActionCreateView:                   "create view",
 	ActionModifyTableCharsetAndCollate: "modify table charset and collate",
 	ActionTruncateTablePartition:       "truncate partition",
+	ActionDropView:                     "drop view",
 }
 
 // String return current ddl action in string


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
For some reason the release-2.1 branch never merged commit 20bc24aef58addbd906513ec13424e5755e6d97a, which adds ActionDropView to the model.

tidb-binlog uses the release-2.1 branch to build, and that means it's impossible for it to handle `DROP VIEW` statements.

### What is changed and how it works?
This branch simply cherry-picks commit 20bc24aef58addbd906513ec13424e5755e6d97a.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

I checked out the release-2.1 branch of tidb-server and it builds fine after making this change.
