### PR TITLE
types: fix Restore of FieldType in handling decimal

### DIFF
--- a/types/field_type.go
+++ b/types/field_type.go
@@ -220,7 +220,7 @@ func (ft *FieldType) Restore(ctx *format.RestoreCtx) error {
 			ctx.WritePlainf("(%d,%d)", ft.Flen, ft.Decimal)
 		}
 	case mysql.TypeNewDecimal:
-		if ft.Flen > 0 && ft.Decimal > 0 {
+		if ft.Flen > 0 && ft.Decimal >= 0 {
 			ctx.WritePlainf("(%d,%d)", ft.Flen, ft.Decimal)
 		}
 	case mysql.TypeBit, mysql.TypeShort, mysql.TypeTiny, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeBlob, mysql.TypeLongBlob, mysql.TypeYear:


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Consider the following create table statement:

```sql
create table t(a decimal(20) not null);
```

If we parse it and restore it will get an unexpected result: `create table t(a decimal not null)`.

The result should keep consistent with `show create table t` which emit `create table t(a decimal(20, 0) not null)`

### What is changed and how it works?

Fix it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

N/A

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
