### PR TITLE
digester: avoid infinite loop when an invalid token is seen

### DIFF
--- a/digester.go
+++ b/digester.go
@@ -111,6 +111,9 @@ func (d *sqlDigester) normalize(sql string) {
 	d.lexer.reset(sql)
 	for {
 		tok, pos, lit := d.lexer.scan()
+		if tok == invalid {
+			break
+		}
 		if tok == unicode.ReplacementChar && d.lexer.r.eof() {
 			break
 		}

--- a/digester_test.go
+++ b/digester_test.go
@@ -50,6 +50,7 @@ func (s *testSQLDigestSuite) TestNormalize(c *C) {
 		// test syntax error, it will be checked by parser, but it should not make normalize dead loop.
 		{"select * from t ignore index(", "select * from t ignore index"},
 		{"select /*+ ", "select "},
+		{"select * from 🥳", "select * from"},
 	}
 	for _, test := range tests {
 		actual := parser.Normalize(test.input)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Starting from pingcap/tidb#10284, executing the following would cause TiDB to enter an infinite loop:

```sql
create table `🥳`(a int);
select * from `🥳`;         -- ← this line
```

This is caused by multiple issues:

1. MySQL [does not permit non-BMP characters](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html) like `🥳` in an identifier, no matter quoted or not. But TiDB's and MySQL's behavior differ on such non-BMP characters.

     * MySQL allows both unquoted `🥳` and quoted `` `🥳` ``, but both will be translated into a question mark `` `?` ``.
     * TiDB treats unquoted `🥳` a lexer error, but accepts the quoted `` `🥳` `` as-is.

2. The `parser.Normalize` strips away the backquotes around the identifier, while MySQL *adds* the backquotes in all cases.

3. Since pingcap/tidb#10284, when we execute a SELECT statement, it will call `GetBindRecord`. The problem is `GetBindRecord` calls `parser.DigestHash` on a *normalized* SQL (pingcap/tidb#10247), so we will double-normalize the statement before computing the hash.

So, up till now, the statement ``SELECT * FROM `🥳`;`` is (1) *accepted* by the parser, (2) *normalized* into ``SELECT * FROM 🥳;``, and (3) normalized again before calculating the hash. 

4. The unquoted `🥳` is treated as a lexer error. The lexer will just return the invalid token without advancing the cursor. This throws the `normalize` function into an infinite loop.

### What is changed and how it works?

Break the infinite loop if a lexer error is encountered, so at least running ``SELECT * FROM `🥳`;`` won't DoS the server. 

We could think of how to fix the other 3 problems in other PRs.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes
