### PR TITLE
test: enable coverage when running unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ y.go
 .idea/
 go.mod
 go.sum
+coverage.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Parser
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/pingcap/parser)](https://goreportcard.com/report/github.com/pingcap/parser) [![CircleCI Status](https://circleci.com/gh/pingcap/parser.svg?style=shield)](https://circleci.com/gh/pingcap/parser) [![GoDoc](https://godoc.org/github.com/pingcap/parser?status.svg)](https://godoc.org/github.com/pingcap/parser)
+[![codecov](https://codecov.io/gh/pingcap/parser/branch/master/graph/badge.svg)](https://codecov.io/gh/pingcap/parser)
 
 TiDB SQL Parser
 

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,9 @@ jobs:
       - run:
           name: "Build & Test"
           command: make test
+      - run:
+          name: "Upload coverage"
+          command: bash <(curl -s https://codecov.io/bash)
   build-integration:
     docker:
     - image: golang:1.11

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 {
 	  mv go.mod1 go.mod
 	  mv go.sum1 go.sum
-	  GO111MODULE=on go test ./...
+	  GO111MODULE=on go test -race -covermode=atomic -coverprofile=coverage.txt ./...
 } || {
 	  mv go.mod go.mod1
 	  mv go.sum go.sum1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

pingcap/parser doesn't have a coverage report of its own.

### What is changed and how it works?

Enabled coverage report from `test.sh`.
Created a codecov project at https://codecov.io/gh/pingcap/parser.
Update coverage to codecov after `make test` succeed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes
