### PR TITLE
ast: fix case expression format bug

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -289,13 +289,14 @@ func (n *CaseExpr) Restore(ctx *RestoreCtx) error {
 
 // Format the ExprNode into a Writer.
 func (n *CaseExpr) Format(w io.Writer) {
-	fmt.Fprint(w, "CASE ")
+	fmt.Fprint(w, "CASE")
 	// Because the presence of `case when` syntax, `Value` could be nil and we need check this.
 	if n.Value != nil {
-		n.Value.Format(w)
 		fmt.Fprint(w, " ")
+		n.Value.Format(w)
 	}
 	for _, clause := range n.WhenClauses {
+		fmt.Fprint(w, " ")
 		fmt.Fprint(w, "WHEN ")
 		clause.Expr.Format(w)
 		fmt.Fprint(w, " THEN ")

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -84,6 +84,7 @@ func (ts *testAstFormatSuite) TestAstFormat(c *C) {
 		{` cast( a as decimal ) `, "CAST(`a` AS DECIMAL(11))"},
 		{` cast( a as decimal (3) ) `, "CAST(`a` AS DECIMAL(3))"},
 		{` cast( a as decimal (3,3) ) `, "CAST(`a` AS DECIMAL(3, 3))"},
+		{` ((case when (c0 = 0) then 0 when (c0 > 0) then (c1 / c0) end)) `, "((CASE WHEN (`c0` = 0) THEN 0 WHEN (`c0` > 0) THEN (`c1` / `c0`) END))"},
 		{` convert (a, signed) `, "CONVERT(`a`, SIGNED)"},
 		{` binary "hello"`, `BINARY "hello"`},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix `caseExpr` format bug.
```
((case when (c0 = 0) then 0 when (c0 > 0) then (c1 / c0) end))
```

before

```
"((CASE WHEN (`c0` = 0) THEN 0WHEN (`c0` > 0) THEN (`c1` / `c0`) END))"

```

now

```
"((CASE WHEN (`c0` = 0) THEN 0 WHEN (`c0` > 0) THEN (`c1` / `c0`) END))"
```

the differents is `THEN 0WHEN` and `THEN 0 WHEN`

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes
