### PR TITLE
ast: add new field in create view stmt

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -1016,14 +1016,15 @@ func (n *TableToTable) Accept(v Visitor) (Node, bool) {
 type CreateViewStmt struct {
 	ddlNode
 
-	OrReplace   bool
-	ViewName    *TableName
-	Cols        []model.CIStr
-	Select      StmtNode
-	Algorithm   model.ViewAlgorithm
-	Definer     *auth.UserIdentity
-	Security    model.ViewSecurity
-	CheckOption model.ViewCheckOption
+	OrReplace    bool
+	ViewName     *TableName
+	Cols         []model.CIStr
+	Select       StmtNode
+	SelectSchema []model.CIStr
+	Algorithm    model.ViewAlgorithm
+	Definer      *auth.UserIdentity
+	Security     model.ViewSecurity
+	CheckOption  model.ViewCheckOption
 }
 
 // Restore implements Node interface.

--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -1016,15 +1016,15 @@ func (n *TableToTable) Accept(v Visitor) (Node, bool) {
 type CreateViewStmt struct {
 	ddlNode
 
-	OrReplace    bool
-	ViewName     *TableName
-	Cols         []model.CIStr
-	Select       StmtNode
-	SelectSchema []model.CIStr
-	Algorithm    model.ViewAlgorithm
-	Definer      *auth.UserIdentity
-	Security     model.ViewSecurity
-	CheckOption  model.ViewCheckOption
+	OrReplace   bool
+	ViewName    *TableName
+	Cols        []model.CIStr
+	Select      StmtNode
+	SchemaCols  []model.CIStr
+	Algorithm   model.ViewAlgorithm
+	Definer     *auth.UserIdentity
+	Security    model.ViewSecurity
+	CheckOption model.ViewCheckOption
 }
 
 // Restore implements Node interface.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix panic when create view using prepare.
### What is changed and how it works?

For https://github.com/pingcap/tidb/pull/10651

> Previously, when we build the create view statement, the Fields of select statement will be rewritten with only name info, so the Expr will be nil when we try to execute the prepare statement, which will cause panic. This PR adds a new field in CreateViewStmt to record the select schema.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - None

Side effects

 - None

Related changes

 - None
