### PR TITLE
add a field that hold binary execut args to ExecuteStmt

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -327,9 +327,10 @@ type Prepared struct {
 type ExecuteStmt struct {
 	stmtNode
 
-	Name      string
-	UsingVars []ExprNode
-	ExecID    uint32
+	Name       string
+	UsingVars  []ExprNode
+	BinaryArgs interface{}
+	ExecID     uint32
 }
 
 // Restore implements Node interface.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

relate to https://github.com/pingcap/tidb/pull/10884

just add a field to ExecuteStmt, this field will be runtime used in TiDB 

### What is changed and how it works?

add a field that hold binary execut args to ExecuteStmt

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - N/A

Side effects

 - N/A

Related changes

 - N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/parser/363)
<!-- Reviewable:end -->
