### PR TITLE
parser: fix hint parsing in `select /*+ max_execution_time */ 1`

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -11178,6 +11178,9 @@ yynewstate:
 				Distinct:       yyS[yypt-1].item.(*ast.SelectStmtOpts).Distinct,
 				Fields:         yyS[yypt-0].item.(*ast.FieldList),
 			}
+			if st.SelectStmtOpts.TableHints != nil {
+				st.TableHints = st.SelectStmtOpts.TableHints
+			}
 			parser.yyVAL.item = st
 		}
 	case 959:
@@ -11196,9 +11199,6 @@ yynewstate:
 		{
 			st := yyS[yypt-6].item.(*ast.SelectStmt)
 			st.From = yyS[yypt-4].item.(*ast.TableRefsClause)
-			if st.SelectStmtOpts.TableHints != nil {
-				st.TableHints = st.SelectStmtOpts.TableHints
-			}
 			lastField := st.Fields.Fields[len(st.Fields.Fields)-1]
 			if lastField.Expr != nil && lastField.AsName.O == "" {
 				lastEnd := parser.endOffset(&yyS[yypt-5])

--- a/parser.y
+++ b/parser.y
@@ -5016,6 +5016,9 @@ SelectStmtBasic:
 			Distinct:      $2.(*ast.SelectStmtOpts).Distinct,
 			Fields:        $3.(*ast.FieldList),
 		}
+		if st.SelectStmtOpts.TableHints != nil {
+			st.TableHints = st.SelectStmtOpts.TableHints
+		}
 		$$ = st
 	}
 
@@ -5039,9 +5042,6 @@ SelectStmtFromTable:
 	{
 		st := $1.(*ast.SelectStmt)
 		st.From = $3.(*ast.TableRefsClause)
-		if st.SelectStmtOpts.TableHints != nil {
-			st.TableHints = st.SelectStmtOpts.TableHints
-		}
 		lastField := st.Fields.Fields[len(st.Fields.Fields)-1]
 		if lastField.Expr != nil && lastField.AsName.O == "" {
 			lastEnd := parser.endOffset(&yyS[yypt-5])


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In this query, `SELECT /*+ MAX_EXECUTION_TIME(1000) */ 1`, the `MAX_EXECUTION_TIME` hint is not saved to `st.TableHints`

https://github.com/pingcap/tidb/issues/10955 is caused by this bug.

### What is changed and how it works?

Move this line

```
st.TableHints = st.SelectStmtOpts.TableHints
```
to `SelectStmtBasic` will address the problem.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

