### PR TITLE
parser: parse SQL statement to the last character

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -211,9 +211,11 @@ func (s *Scanner) Lex(v *yySymType) int {
 	case quotedIdentifier:
 		tok = identifier
 	}
-	if tok == unicode.ReplacementChar && s.r.eof() {
-		return 0
+
+	if tok == unicode.ReplacementChar {
+		return invalid
 	}
+
 	return tok
 }
 

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -356,18 +356,18 @@ func (s *testLexerSuite) TestSQLModeANSIQuotes(c *C) {
 
 func (s *testLexerSuite) TestIllegal(c *C) {
 	table := []testCaseItem{
-		{"'", 0},
-		{"'fu", 0},
-		{"'\\n", 0},
-		{"'\\", 0},
+		{"'", invalid},
+		{"'fu", invalid},
+		{"'\\n", invalid},
+		{"'\\", invalid},
 		{fmt.Sprintf("%c", 0), invalid},
-		{"`", 0},
-		{`"`, 0},
-		{"@`", 0},
-		{"@'", 0},
-		{`@"`, 0},
-		{"@@`", 0},
-		{"@@global.`", 0},
+		{"`", invalid},
+		{`"`, invalid},
+		{"@`", invalid},
+		{"@'", invalid},
+		{`@"`, invalid},
+		{"@@`", invalid},
+		{"@@global.`", invalid},
 	}
 	runTest(c, table)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix TiDB [issue #10906](https://github.com/pingcap/tidb/issues/10906).

### What is changed and how it works?

When a SQL statement ends with an invalid part, i.e ` drop table if exists t'xyz`, Scanner's scanString() treat `'xzy` as an incomplete string, and returns `unicode.PlacementChar`.

However, the Lex() incorrectly converts it into a `0`, which means EOF, making it impossible to distinguish from `drop table if exists t`.

So, as long as an invalid token is spotted, the code indicating invalid should be returned.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)
