### PR TITLE
parser: fix hint parsing in `select /*+ max_execution_time */ 1` (#366)

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -9953,6 +9953,9 @@ yynewstate:
 				Distinct:       yyS[yypt-1].item.(*ast.SelectStmtOpts).Distinct,
 				Fields:         yyS[yypt-0].item.(*ast.FieldList),
 			}
+			if st.SelectStmtOpts.TableHints != nil {
+				st.TableHints = st.SelectStmtOpts.TableHints
+			}
 			parser.yyVAL.item = st
 		}
 	case 861:
@@ -9971,9 +9974,6 @@ yynewstate:
 		{
 			st := yyS[yypt-6].item.(*ast.SelectStmt)
 			st.From = yyS[yypt-4].item.(*ast.TableRefsClause)
-			if st.SelectStmtOpts.TableHints != nil {
-				st.TableHints = st.SelectStmtOpts.TableHints
-			}
 			lastField := st.Fields.Fields[len(st.Fields.Fields)-1]
 			if lastField.Expr != nil && lastField.AsName.O == "" {
 				lastEnd := parser.endOffset(&yyS[yypt-5])

--- a/parser.y
+++ b/parser.y
@@ -4518,6 +4518,9 @@ SelectStmtBasic:
 			Distinct:      $2.(*ast.SelectStmtOpts).Distinct,
 			Fields:        $3.(*ast.FieldList),
 		}
+		if st.SelectStmtOpts.TableHints != nil {
+			st.TableHints = st.SelectStmtOpts.TableHints
+		}
 		$$ = st
 	}
 
@@ -4541,9 +4544,6 @@ SelectStmtFromTable:
 	{
 		st := $1.(*ast.SelectStmt)
 		st.From = $3.(*ast.TableRefsClause)
-		if st.SelectStmtOpts.TableHints != nil {
-			st.TableHints = st.SelectStmtOpts.TableHints
-		}
 		lastField := st.Fields.Fields[len(st.Fields.Fields)-1]
 		if lastField.Expr != nil && lastField.AsName.O == "" {
 			lastEnd := parser.endOffset(&yyS[yypt-5])

--- a/parser_test.go
+++ b/parser_test.go
@@ -1892,13 +1892,21 @@ func (s *testParserSuite) TestOptimizerHints(c *C) {
 	c.Assert(hints[1].Tables[0].L, Equals, "t3")
 	c.Assert(hints[1].Tables[1].L, Equals, "t4")
 
-	stmt, _, err = parser.Parse("SELECT /*+ MAX_EXECUTION_TIME(1000) */ * FROM t1 INNER JOIN t2 where t1.c1 = t2.c1", "", "")
-	c.Assert(err, IsNil)
-	selectStmt = stmt[0].(*ast.SelectStmt)
-	hints = selectStmt.TableHints
-	c.Assert(len(hints), Equals, 1)
-	c.Assert(hints[0].HintName.L, Equals, "max_execution_time")
-	c.Assert(hints[0].MaxExecutionTime, Equals, uint64(1000))
+	queries := []string{
+		"SELECT /*+ MAX_EXECUTION_TIME(1000) */ * FROM t1 INNER JOIN t2 where t1.c1 = t2.c1",
+		"SELECT /*+ MAX_EXECUTION_TIME(1000) */ 1",
+		"SELECT /*+ MAX_EXECUTION_TIME(1000) */ SLEEP(20)",
+		"SELECT /*+ MAX_EXECUTION_TIME(1000) */ 1 FROM DUAL",
+	}
+	for i, query := range queries {
+		stmt, _, err = parser.Parse(query, "", "")
+		c.Assert(err, IsNil)
+		selectStmt = stmt[0].(*ast.SelectStmt)
+		hints = selectStmt.TableHints
+		c.Assert(len(hints), Equals, 1)
+		c.Assert(hints[0].HintName.L, Equals, "max_execution_time", Commentf("case", i))
+		c.Assert(hints[0].MaxExecutionTime, Equals, uint64(1000))
+	}
 }
 
 func (s *testParserSuite) TestType(c *C) {


### PR DESCRIPTION
Cherry-pick from https://github.com/pingcap/parser/pull/366

PTAL @jackysp @kennytm 