### PR TITLE
ast: add BinaryLiteral interface

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -2033,8 +2033,12 @@ func (n *TableOptimizerHint) Accept(v Visitor) (Node, bool) {
 // NewDecimal creates a types.Decimal value, it's provided by parser driver.
 var NewDecimal func(string) (interface{}, error)
 
+type BinaryLiteral interface {
+	ToString() string
+}
+
 // NewHexLiteral creates a types.HexLiteral value, it's provided by parser driver.
-var NewHexLiteral func(string) (interface{}, error)
+var NewHexLiteral func(string) (BinaryLiteral, error)
 
 // NewBitLiteral creates a types.BitLiteral value, it's provided by parser driver.
-var NewBitLiteral func(string) (interface{}, error)
+var NewBitLiteral func(string) (BinaryLiteral, error)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#365 need to change the `NewHexLiteral` driver's return type to an new interface type `BinaryLiteral`.
There are also some change in TiDB side.

### What is changed and how it works?
Change return  type of `NewHexLiteral` and `NewBitLiteral`. Adding `BinaryLiteral` interface.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change
