### PR TITLE
mysql: add a new state `ErrInvalidJSONPathArrayCell`

### DIFF
--- a/mysql/state.go
+++ b/mysql/state.go
@@ -255,4 +255,5 @@ var MySQLState = map[uint16]string{
 	ErrInvalidJSONData:                     "22032",
 	ErrInvalidJSONPathWildcard:             "42000",
 	ErrJSONUsedAsKey:                       "42000",
+	ErrInvalidJSONPathArrayCell:            "42000",
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

There is no state for `ErrInvalidJSONPathArrayCell`.

### What is changed and how it works?

``` mysql
mysql> SELECT JSON_ARRAY_INSERT('[1]', '$.a', 'a');
ERROR 3165 (42000): A path expression is not a path to a cell in an array.
```