### PR TITLE
test: count coverage for all packages when unit testing

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,8 @@
 {
 	  mv go.mod1 go.mod
 	  mv go.sum1 go.sum
-	  GO111MODULE=on go test -race -covermode=atomic -coverprofile=coverage.txt ./...
+	  GO111MODULE=on go test -race ./... &&
+	  GO111MODULE=on go test -covermode=set -coverprofile=coverage.txt -coverpkg=./... ./...
 } || {
 	  mv go.mod go.mod1
 	  mv go.sum go.sum1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

By default, when testing package A with coverage, only lines in package A will be counted towards the final report, even if the tests called functions from package B.

In this project, however, almost all of our tests are written to `parser_test.go`. Thus even if `parser_test.go` invoked many functions in `ast/*` (package B), those coverages will be lost since `parser_test.go` is outside this directory (in package A).

### What is changed and how it works?

We changed the default to tell Go to count coverage for all packages regardless of the source. The coverage report should be closer to reality.

It seems like covering all packages in `atomic` mode uses too much RAM for CircleCI when compiling (see attempts 2300, 2302 and 2305 in https://circleci.com/gh/pingcap/parser/tree/pull%2F377), so the test is split into two runs: once with race detector only and once with coverage only.

(An alternative is to split `parser_test.go` but I don't see much benefits doing so.)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes
