### PR TITLE
utils: `IsReadOnly` returns wrong result when checking SQLs like `explain analyze insert ...`

### DIFF
--- a/ast/util.go
+++ b/ast/util.go
@@ -28,10 +28,7 @@ func IsReadOnly(node Node) bool {
 		node.Accept(&checker)
 		return checker.readOnly
 	case *ExplainStmt:
-		if !st.Analyze {
-			return true
-		}
-		return IsReadOnly(st.Stmt)
+		return !st.Analyze || IsReadOnly(st.Stmt)
 	case *DoStmt:
 		return true
 	default:

--- a/ast/util.go
+++ b/ast/util.go
@@ -27,7 +27,12 @@ func IsReadOnly(node Node) bool {
 
 		node.Accept(&checker)
 		return checker.readOnly
-	case *ExplainStmt, *DoStmt:
+	case *ExplainStmt:
+		if !st.Analyze {
+			return true
+		}
+		return IsReadOnly(st.Stmt)
+	case *DoStmt:
 		return true
 	default:
 		return false

--- a/ast/util_test.go
+++ b/ast/util_test.go
@@ -48,6 +48,29 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 
 	stmt = &DoStmt{}
 	c.Assert(IsReadOnly(stmt), IsTrue)
+
+	stmt = &ExplainStmt{
+		Stmt: &InsertStmt{},
+	}
+	c.Assert(IsReadOnly(stmt), IsTrue)
+
+	stmt = &ExplainStmt{
+		Analyze: true,
+		Stmt:    &InsertStmt{},
+	}
+	c.Assert(IsReadOnly(stmt), IsFalse)
+
+	stmt = &ExplainStmt{
+		Stmt: &SelectStmt{},
+	}
+	c.Assert(IsReadOnly(stmt), IsTrue)
+
+	stmt = &ExplainStmt{
+		Analyze: true,
+		Stmt:    &SelectStmt{},
+	}
+	c.Assert(IsReadOnly(stmt), IsTrue)
+
 }
 
 // CleanNodeText set the text of node and all child node empty.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
SQLs like `explain analyze insert into t values (1)` are not read-only, but the `IsReadOnly` function regards them as read-only queries.

### What is changed and how it works?
Let `IsReadOnly `checks the `Analyze` flag and the internal `Stmt` of `ExplainStmt` to decide if it is `ReadOnly`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

