### PR TITLE
Do not compile unit test in parallel

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,7 @@
 {
 	  mv go.mod1 go.mod
 	  mv go.sum1 go.sum
-	  GO111MODULE=on go test -race ./... &&
-	  GO111MODULE=on go test -covermode=set -coverprofile=coverage.txt -coverpkg=./... ./...
+	  GO111MODULE=on go test -p 1 -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...
 } || {
 	  mv go.mod go.mod1
 	  mv go.sum go.sum1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Do not compile tests in parallel, to avoid the compiler OOM inside CircleCI (which has 2 cores + 4 GiB RAM).

### What is changed and how it works?

Add `-p 1` to limit the number of parallel compiler jobs. 

Merged the two tests back together since there is more space for memory.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes
