### PR TITLE
parser: support cast as double

### DIFF
--- a/mysql/util.go
+++ b/mysql/util.go
@@ -79,6 +79,7 @@ var defaultLengthAndDecimalForCast = map[byte]lengthAndDecimal{
 	TypeNewDecimal: {11, 0},
 	TypeDuration:   {10, 0},
 	TypeLonglong:   {22, 0},
+	TypeDouble:     {22, -1},
 	TypeJSON:       {4194304, 0}, // Flen differs.
 }
 

--- a/parser.y
+++ b/parser.y
@@ -5071,6 +5071,15 @@ CastType:
 		x.Collate = mysql.DefaultCollationName
 		$$ = x
 	}
+|	"DOUBLE"
+	{
+		x := types.NewFieldType(mysql.TypeDouble)
+		x.Flen, x.Decimal = mysql.GetDefaultFieldLengthAndDecimalForCast(mysql.TypeDouble)
+		x.Flag |= mysql.BinaryFlag
+		x.Charset = charset.CharsetBin
+		x.Collate = charset.CollationBin
+		$$ = x
+	}
 
 PriorityOpt:
 	{

--- a/parser_test.go
+++ b/parser_test.go
@@ -1105,6 +1105,9 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		// for cast as signed int, fix issue #3691.
 		{"select cast(1 as signed int);", true, "SELECT CAST(1 AS SIGNED)"},
 
+		// for cast as double
+		{"select cast(1 as double);", true, "SELECT CAST(1 AS DOUBLE)"},
+
 		// for last_insert_id
 		{"SELECT last_insert_id();", true, "SELECT LAST_INSERT_ID()"},
 		{"SELECT last_insert_id(1);", true, "SELECT LAST_INSERT_ID(1)"},

--- a/types/field_type.go
+++ b/types/field_type.go
@@ -299,6 +299,8 @@ func (ft *FieldType) RestoreAsCastType(ctx *format.RestoreCtx) {
 		}
 	case mysql.TypeJSON:
 		ctx.WriteKeyWord("JSON")
+	case mysql.TypeDouble:
+		ctx.WriteKeyWord("DOUBLE")
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Related TiDB PR: https://github.com/pingcap/tidb/pull/11443
Support `cast(xxx as double)`.
Mysql support the parser in 8.0.17.
https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html