### PR TITLE
ast: fix the bug of TableSource.Restore()

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -187,12 +187,15 @@ type TableName struct {
 }
 
 // Restore implements Node interface.
-func (n *TableName) Restore(ctx *RestoreCtx) error {
+func (n *TableName) restoreName(ctx *RestoreCtx) {
 	if n.Schema.String() != "" {
 		ctx.WriteName(n.Schema.String())
 		ctx.WritePlain(".")
 	}
 	ctx.WriteName(n.Name.String())
+}
+
+func (n *TableName) restorePartitions(ctx *RestoreCtx) {
 	if len(n.PartitionNames) > 0 {
 		ctx.WriteKeyWord(" PARTITION")
 		ctx.WritePlain("(")
@@ -204,6 +207,9 @@ func (n *TableName) Restore(ctx *RestoreCtx) error {
 		}
 		ctx.WritePlain(")")
 	}
+}
+
+func (n *TableName) restoreIndexHints(ctx *RestoreCtx) error {
 	for _, value := range n.IndexHints {
 		ctx.WritePlain(" ")
 		if err := value.Restore(ctx); err != nil {
@@ -212,6 +218,12 @@ func (n *TableName) Restore(ctx *RestoreCtx) error {
 	}
 
 	return nil
+}
+
+func (n *TableName) Restore(ctx *RestoreCtx) error {
+	n.restoreName(ctx)
+	n.restorePartitions(ctx)
+	return n.restoreIndexHints(ctx)
 }
 
 // IndexHintType is the type for index hint use, ignore or force.

--- a/ast/dml_test.go
+++ b/ast/dml_test.go
@@ -122,7 +122,7 @@ func (tc *testDMLSuite) TestTableNameIndexHintsRestore(c *C) {
 		{"t use index for order by (`foo``bar`) ignore key for group by (`baz``1`, `xyz`)", "`t` USE INDEX FOR ORDER BY (`foo``bar`) IGNORE INDEX FOR GROUP BY (`baz``1`, `xyz`)"},
 	}
 	extractNodeFunc := func(node Node) Node {
-		return node.(*SelectStmt).From.TableRefs.Left.(*TableSource).Source.(*TableName)
+		return node.(*SelectStmt).From.TableRefs.Left
 	}
 	RunNodeRestoreTest(c, testCases, "SELECT * FROM %s", extractNodeFunc)
 }

--- a/ast/dml_test.go
+++ b/ast/dml_test.go
@@ -120,6 +120,9 @@ func (tc *testDMLSuite) TestTableNameIndexHintsRestore(c *C) {
 		{"t use index for group by (`foo``bar`) ignore key for order by (`baz``1`, `xyz`)", "`t` USE INDEX FOR GROUP BY (`foo``bar`) IGNORE INDEX FOR ORDER BY (`baz``1`, `xyz`)"},
 		{"t use index for group by (`foo``bar`) ignore key for group by (`baz``1`, `xyz`)", "`t` USE INDEX FOR GROUP BY (`foo``bar`) IGNORE INDEX FOR GROUP BY (`baz``1`, `xyz`)"},
 		{"t use index for order by (`foo``bar`) ignore key for group by (`baz``1`, `xyz`)", "`t` USE INDEX FOR ORDER BY (`foo``bar`) IGNORE INDEX FOR GROUP BY (`baz``1`, `xyz`)"},
+
+		{"t tt use index for order by (`foo``bar`) ignore key for group by (`baz``1`, `xyz`)", "`t` AS `tt` USE INDEX FOR ORDER BY (`foo``bar`) IGNORE INDEX FOR GROUP BY (`baz``1`, `xyz`)"},
+		{"t as tt use index for order by (`foo``bar`) ignore key for group by (`baz``1`, `xyz`)", "`t` AS `tt` USE INDEX FOR ORDER BY (`foo``bar`) IGNORE INDEX FOR GROUP BY (`baz``1`, `xyz`)"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*SelectStmt).From.TableRefs.Left
@@ -247,6 +250,20 @@ func (tc *testDMLSuite) TestDeleteTableListRestore(c *C) {
 	}
 	RunNodeRestoreTest(c, testCases, "DELETE %s FROM t1, t2;", extractNodeFunc)
 	RunNodeRestoreTest(c, testCases, "DELETE FROM %s USING t1, t2;", extractNodeFunc)
+}
+
+func (tc *testDMLSuite) TestDeleteTableIndexHintRestore(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"DELETE FROM t1 USE key (`fld1`) WHERE fld=1",
+			"DELETE FROM `t1` USE INDEX (`fld1`) WHERE `fld`=1"},
+		{"DELETE FROM t1 as tbl USE key (`fld1`) WHERE tbl.fld=2",
+			"DELETE FROM `t1` AS `tbl` USE INDEX (`fld1`) WHERE `tbl`.`fld`=2"},
+	}
+
+	extractNodeFunc := func(node Node) Node {
+		return node.(*DeleteStmt)
+	}
+	RunNodeRestoreTest(c, testCases, "%s", extractNodeFunc)
 }
 
 func (tc *testExpressionsSuite) TestByItemRestore(c *C) {


### PR DESCRIPTION
fix #538. `Restore` method generates incorrect SQL when both table's 'asName' and index hints are present

### What is changed and how it works?


### Check List
Tests <!-- At least one of them must be included. -->
 - Unit test
   added

Code changes
 - Has exported function/method change
  no
 - Has exported variable/fields change
  no
 - Has interface methods change
  no

Side effects
 - Possible performance regression
  none
 - Increased code complexity
  special case in `TableSource.Restore` created
 - Breaking backward compatibility
  no


Closes #538