### PR TITLE
Adds GBK charset

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -63,6 +63,7 @@ var charsetInfos = []*Charset{
 	{CharsetASCII, CollationASCII, make(map[string]*Collation), "US ASCII", 1},
 	{CharsetLatin1, CollationLatin1, make(map[string]*Collation), "Latin1", 1},
 	{CharsetBin, CollationBin, make(map[string]*Collation), "binary", 1},
+	{CharsetGBK, CollationGBK, make(map[string]*Collation), "GBK Simplified Chinese", 2},
 }
 
 // All the names supported collations should be in the following table.
@@ -72,6 +73,7 @@ var supportedCollationNames = map[string]struct{}{
 	CollationASCII:   {},
 	CollationLatin1:  {},
 	CollationBin:     {},
+	CollationGBK:     {},
 }
 
 // Desc is a charset description.
@@ -207,6 +209,10 @@ const (
 	CharsetLatin1 = "latin1"
 	// CollationLatin1 is the default collation for CharsetLatin1.
 	CollationLatin1 = "latin1_bin"
+	// CharsetGBK is a character set for simplified Chinese characters
+	CharsetGBK = "gbk"
+	// CollationGBK is the dfeault collation for CharsetGBK
+	CollationGBK = "gbk_chinese_ci"
 )
 
 var collations = []*Collation{

--- a/charset/charset_test.go
+++ b/charset/charset_test.go
@@ -56,6 +56,7 @@ func (s *testCharsetSuite) TestValidCharset(c *C) {
 		{"UTF8MB4", "UTF8MB4_bin", true},
 		{"UTF8MB4", "UTF8MB4_general_ci", true},
 		{"Utf8", "uTf8_bIN", true},
+		{"Gbk", "gbK_chinese_Ci", true},
 	}
 	for _, tt := range tests {
 		testValidCharset(c, tt.cs, tt.co, tt.succ)


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/pingcap/parser/issues/525

### What is changed and how it works?

Added GBK as a default, supported charset and collation as per:
https://mariadb.com/kb/en/library/supported-character-sets-and-collations/

### Check List

#### Tests
 - Unit test

#### Code changes
 - Has exported variable/fields change

#### Side effects
None expected.

#### Related changes
Unsure