### PR TITLE
parser: optimize performance

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -8788,7 +8788,6 @@ func yyParse(yylex yyLexer, parser *Parser) int {
 	yyEx, _ := yylex.(yyLexerEx)
 	var yyn int
 	parser.yylval = yySymType{}
-	parser.yyVAL = yySymType{}
 	yyS := parser.cache
 
 	Nerrs := 0   /* number of errors */
@@ -8816,13 +8815,13 @@ ret1:
 yystack:
 	/* put a state and value onto the stack */
 	yyp++
-	if yyp >= len(yyS) {
+	if yyp+1 >= len(yyS) {
 		nyys := make([]yySymType, len(yyS)*2)
 		copy(nyys, yyS)
 		yyS = nyys
 		parser.cache = yyS
 	}
-	yyS[yyp] = parser.yyVAL
+	parser.yyVAL = &yyS[yyp+1]
 	yyS[yyp].yys = yystate
 
 yynewstate:
@@ -8850,7 +8849,7 @@ yynewstate:
 	switch {
 	case yyn > 0: // shift
 		yychar = -1
-		parser.yyVAL = parser.yylval
+		*parser.yyVAL = parser.yylval
 		yystate = yyn
 		yyshift = yyn
 		if yyDebug >= 2 {
@@ -8948,7 +8947,7 @@ yynewstate:
 		yyS = nyys
 		parser.cache = yyS
 	}
-	parser.yyVAL = yyS[yyp+1]
+	parser.yyVAL = &yyS[yyp+1]
 
 	/* consult goto table to find next state */
 	exState := yystate
@@ -16717,7 +16716,7 @@ yynewstate:
 
 	}
 
-	if yyEx != nil && yyEx.Reduced(r, exState, &parser.yyVAL) {
+	if yyEx != nil && yyEx.Reduced(r, exState, parser.yyVAL) {
 		return -1
 	}
 	goto yystack /* stack new state and value */

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -100,7 +100,7 @@ type Parser struct {
 	// the following fields are used by yyParse to reduce allocation.
 	cache  []yySymType
 	yylval yySymType
-	yyVAL  yySymType
+	yyVAL  *yySymType
 }
 
 type stmtTexter interface {


### PR DESCRIPTION
### What problem does this PR solve?
Optimizing parser performance

### What is changed and how it works?
Here is the benchmark, 8%~12% faster than before:

goos: linux
goarch: amd64

Before optimization:
```sh
BenchmarkSysbenchSelect       200000          6121 ns/op        1824 B/op         20 allocs/op
BenchmarkParseComplex          10000        223586 ns/op        61772 B/op        642 allocs/op
BenchmarkParseSimple          100000         19047 ns/op        5144 B/op         71 allocs/op
```
After optimization:
```sh
BenchmarkSysbenchSelect       200000          5586 ns/op        1824 B/op         20 allocs/op
BenchmarkParseComplex          10000        206988 ns/op        61772 B/op        642 allocs/op
BenchmarkParseSimple          100000         16873 ns/op        5144 B/op         71 allocs/op
```

### Check List
Tests

Unit test