### PR TITLE
.github: add CODEOWNER rule to request review for PRs automatically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pingcap/co-parser


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

I added a CODEOWNER rule for this repo, which automatically request the @pingcap/co-parser to review the open PRs.

### What is changed and how it works?

1. **[done]** installed the [pull assigner](https://github.com/apps/pull-assigner) app for the `pingcap/parser` repo
2. **[done]** created a team named `co-parser` in the `pingcap` account. `co` is short for `codeowner`.
3. create the codeowner rule for this repo, make the codeowner to be `co-parser`

After all these 3 steps, in which this PR is the last step, once a PR in this repo is filed:
1. github automatically request `co-parser` to review that PR
2. pull assigner automatically chose 1, which is configurable, person in that team to review that PR and remove the review request on that team.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code