### PR TITLE
mysql: add 2 infoschema related errors for TiDB

### DIFF
--- a/mysql/errcode.go
+++ b/mysql/errcode.go
@@ -953,7 +953,7 @@ const (
 	ErrInvalidTxn                 = 8024
 	ErrEntryTooLarge              = 8025
 	ErrNotImplemented             = 8026
-	ErrInfoSchemaOutOfDate        = 8027
+	ErrInfoSchemaExpired          = 8027
 	ErrInfoSchemaChanged          = 8028
 
 	// TiKV/PD errors.

--- a/mysql/errcode.go
+++ b/mysql/errcode.go
@@ -953,6 +953,8 @@ const (
 	ErrInvalidTxn                 = 8024
 	ErrEntryTooLarge              = 8025
 	ErrNotImplemented             = 8026
+	ErrInfoSchemaOutOfDate        = 8027
+	ErrInfoSchemaChanged          = 8028
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout    = 9001

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -949,7 +949,7 @@ var MySQLErrName = map[uint16]string{
 	ErrInvalidTxn:                 "invalid transaction",
 	ErrEntryTooLarge:              "entry too large, the max entry size is %d, the size of data is %d",
 	ErrNotImplemented:             "not implemented",
-	ErrInfoSchemaOutOfDate:        "Information schema is out of date: schema failed to update in 1 lease",
+	ErrInfoSchemaExpired:          "Information schema is out of date: schema failed to update in 1 lease",
 	ErrInfoSchemaChanged:          "Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`[retryable]",
 
 	// TiKV/PD errors.

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -950,7 +950,7 @@ var MySQLErrName = map[uint16]string{
 	ErrEntryTooLarge:              "entry too large, the max entry size is %d, the size of data is %d",
 	ErrNotImplemented:             "not implemented",
 	ErrInfoSchemaExpired:          "Information schema is out of date: schema failed to update in 1 lease",
-	ErrInfoSchemaChanged:          "Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`[retryable]",
+	ErrInfoSchemaChanged:          "Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`",
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout:    "PD server timeout",

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -949,7 +949,7 @@ var MySQLErrName = map[uint16]string{
 	ErrInvalidTxn:                 "invalid transaction",
 	ErrEntryTooLarge:              "entry too large, the max entry size is %d, the size of data is %d",
 	ErrNotImplemented:             "not implemented",
-	ErrInfoSchemaExpired:          "Information schema is out of date: schema failed to update in 1 lease",
+	ErrInfoSchemaExpired:          "Information schema is out of date: schema failed to update in 1 lease, please make sure TiDB can connect to TiKV",
 	ErrInfoSchemaChanged:          "Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`",
 
 	// TiKV/PD errors.

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -949,6 +949,8 @@ var MySQLErrName = map[uint16]string{
 	ErrInvalidTxn:                 "invalid transaction",
 	ErrEntryTooLarge:              "entry too large, the max entry size is %d, the size of data is %d",
 	ErrNotImplemented:             "not implemented",
+	ErrInfoSchemaOutOfDate:        "Information schema is out of date: schema failed to update in 1 lease",
+	ErrInfoSchemaChanged:          "Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`[retryable]",
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout:    "PD server timeout",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some errors in TiDB do not have an error code. Add parts of them.

Side effects

 - Breaking backward compatibility
