### PR TITLE
parser: fix the select field text [DNM]

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -13159,9 +13159,15 @@ yynewstate:
 			st.LockTp = yyS[yypt-0].item.(ast.SelectLockType)
 			if yyS[yypt-2].item != nil {
 				st.OrderBy = yyS[yypt-2].item.(*ast.OrderByClause)
+
+				endOffset := parser.endOffset(&yyS[yypt-2])
+				parser.setLastSelectFieldText(st, endOffset)
 			}
 			if yyS[yypt-1].item != nil {
 				st.Limit = yyS[yypt-1].item.(*ast.Limit)
+
+				endOffset := parser.endOffset(&yyS[yypt-1])
+				parser.setLastSelectFieldText(st, endOffset)
 			}
 			parser.yyVAL.statement = st
 		}

--- a/parser.y
+++ b/parser.y
@@ -6099,9 +6099,15 @@ SelectStmt:
 		st.LockTp = $4.(ast.SelectLockType)
 		if $2 != nil {
 			st.OrderBy = $2.(*ast.OrderByClause)
+
+			endOffset := parser.endOffset(&yyS[yypt-2])
+			parser.setLastSelectFieldText(st, endOffset)
 		}
 		if $3 != nil {
 			st.Limit = $3.(*ast.Limit)
+
+			endOffset := parser.endOffset(&yyS[yypt-1])
+			parser.setLastSelectFieldText(st, endOffset)
 		}
 		$$ = st
 	}


### PR DESCRIPTION
Try to fix the select field text bug introduced in https://github.com/pingcap/parser/pull/587

```
mysql> SELECT @@`autocommit` LIMIT 1;
+------------------------+
| @@`autocommit` LIMIT 1 |
+------------------------+
| 1                      |
+------------------------+
1 row in set (0.00 sec)
```

which should be

```
mysql> SELECT @@`autocommit`;
+----------------+
| @@`autocommit` |
+----------------+
| 1              |
+----------------+
1 row in set (0.00 sec)
```

I'm not sure it's a good fix, pr/587 seems to introduce some other problems.
For example, is this a correct gramma in MySQL?

```
select 1 where true group by 1 having 1>0
```