### PR TITLE
mysql: add error code and message for table related to error

### DIFF
--- a/mysql/errcode.go
+++ b/mysql/errcode.go
@@ -963,6 +963,15 @@ const (
 	ErrIncorrectDatetimeValue     = 8034
 	ErrInvalidTimeFormat          = 8036
 	ErrInvalidWeekModeFormat      = 8037
+	ErrFieldGetDefaultFailed      = 8038
+	ErrIndexOutBound              = 8039
+	ErrUnsupportedOp              = 8040
+	ErrRowNotFound                = 8041
+	ErrTableStateCantNone         = 8042
+	ErrColumnStateNonPublic       = 8043
+	ErrIndexStateCantNone         = 8044
+	ErrInvalidRecordKey           = 8045
+	ErrColumnStateCantNone        = 8046
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout    = 9001

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -964,7 +964,7 @@ var MySQLErrName = map[uint16]string{
 	ErrUnsupportedOp:              "operation not supported",
 	ErrRowNotFound:                "can not find the row: %s",
 	ErrTableStateCantNone:         "table %s can't be in none state",
-	ErrColumnStateCantNone:        "column %s can't be in non",
+	ErrColumnStateCantNone:        "column %s can't be in none state",
 	ErrColumnStateNonPublic:       "can not use non-public column",
 	ErrIndexStateCantNone:         "index %s can't be in none state",
 	ErrInvalidRecordKey:           "invalid record key",

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -959,6 +959,15 @@ var MySQLErrName = map[uint16]string{
 	ErrIncorrectDatetimeValue:     "Incorrect datetime value: '%s'",
 	ErrInvalidTimeFormat:          "invalid time format: '%v'",
 	ErrInvalidWeekModeFormat:      "invalid week mode format: '%v'",
+	ErrFieldGetDefaultFailed:      "Field '%s' get default value fail",
+	ErrIndexOutBound:              "Index column %s offset out of bound, offset: %d, row: %v",
+	ErrUnsupportedOp:              "operation not supported",
+	ErrRowNotFound:                "can not find the row: %s",
+	ErrTableStateCantNone:         "table %s can't be in none state",
+	ErrColumnStateCantNone:        "column %s can't be in non",
+	ErrColumnStateNonPublic:       "can not use non-public column",
+	ErrIndexStateCantNone:         "index %s can't be in none state",
+	ErrInvalidRecordKey:           "invalid record key",
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout:    "PD server timeout",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Originally, some errors were defined by TiDB and use self-edfined error code, which will show default error code `1105` and make user confused.

### What is changed and how it works?
Create error code and message related to table. 
Format error message.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Code changes


Side effects


Related changes
