### PR TITLE
parser: add mysql error `ErrIncorrectType`

### DIFF
--- a/mysql/errcode.go
+++ b/mysql/errcode.go
@@ -884,6 +884,7 @@ const (
 	ErrErrorLast                                                    = 1863
 	ErrMaxExecTimeExceeded                                          = 1907
 	ErrInvalidFieldSize                                             = 3013
+	ErrIncorrectType                                                = 3064
 	ErrInvalidJSONData                                              = 3069
 	ErrGeneratedColumnFunctionIsNotAllowed                          = 3102
 	ErrUnsupportedAlterInplaceOnVirtualColumn                       = 3103

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -888,6 +888,7 @@ var MySQLErrName = map[uint16]string{
 	ErrDependentByGeneratedColumn:                            "Column '%s' has a generated column dependency.",
 	ErrGeneratedColumnRefAutoInc:                             "Generated column '%s' cannot refer to auto-increment column.",
 	ErrInvalidFieldSize:                                      "Invalid size for column '%s'.",
+	ErrIncorrectType:                                         "Incorrect type for argument %s in function %s.",
 	ErrInvalidJSONData:                                       "Invalid JSON data provided to function %s: %s",
 	ErrInvalidJSONText:                                       "Invalid JSON text: %-.192s",
 	ErrInvalidJSONPath:                                       "Invalid JSON path expression %s.",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

add mysql error `ErrIncorrectType`

> Error number: `3064`; Symbol: `[ER_INCORRECT_TYPE]`; SQLSTATE: `HY000`
Message: Incorrect type for argument %s in function %s.

see https://dev.mysql.com/doc/refman/8.0/en/server-error-reference.html#error_er_incorrect_type

### What is changed and how it works?

add mysql error `ErrIncorrectType`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - None

Code changes

 - Has exported variable/fields change

Side effects

 - None

Related changes

 - None
