### PR TITLE
 *: bump the Go compiler version to 1.13

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build-ut:
     docker:
-      - image: golang:1.11
+      - image: golang:1.13
     working_directory: /go/src/github.com/pingcap/parser
     steps:
       - checkout
@@ -24,7 +24,7 @@ jobs:
           command: bash <(curl -s https://codecov.io/bash)
   build-integration:
     docker:
-    - image: golang:1.11
+    - image: golang:1.13
     working_directory: /go/src/github.com/pingcap/parser
     steps:
     - checkout

--- a/go.mod1
+++ b/go.mod1
@@ -14,3 +14,5 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
 )
+
+go 1.13


### PR DESCRIPTION
For the 3.0 branch.
See also https://github.com/pingcap/parser/pull/593