### PR TITLE
for pop up Run... and Debug...  when right-clicking the file lexer_test.go

### DIFF
--- a/lexer_test.go
+++ b/lexer_test.go
@@ -22,12 +22,11 @@ import (
 	"github.com/pingcap/parser/mysql"
 )
 
-
-
 func TestT(t *testing.T) {
 	CustomVerboseFlag = true
 	TestingT(t)
 }
+
 var _ = Suite(&testLexerSuite{})
 
 type testLexerSuite struct {

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/pingcap/parser/mysql"
 )
 
+
+
 func TestT(t *testing.T) {
 	CustomVerboseFlag = true
 	TestingT(t)

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -15,12 +15,17 @@ package parser
 
 import (
 	"fmt"
+	"testing"
 	"unicode"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/mysql"
 )
 
+func TestT(t *testing.T) {
+	CustomVerboseFlag = true
+	TestingT(t)
+}
 var _ = Suite(&testLexerSuite{})
 
 type testLexerSuite struct {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
when I right-clicking the file lexer_test.go, there is not a sub-menu Run 'lexer_test.go' and Debug 'lexer_test.go'

### What is changed and how it works?
Like parser_test.go, I added the following function:

    func TestT(t *testing.T) {
        	CustomVerboseFlag = true
	       TestingT(t)
    }

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
