### PR TITLE
add `GlobalDBVisible` to  represent global privilege which can see all database

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -253,6 +253,9 @@ const (
 // If it's passed to RequestVerification, it means any privilege would be OK.
 const AllPrivMask = AllPriv - 1
 
+// GlobalDBVisible is a collection of global privileges which allow user to see all databases name.
+const GlobalDBVisible = CreatePriv | SelectPriv | InsertPriv | UpdatePriv | DeletePriv | ShowDBPriv | DropPriv | AlterPriv | IndexPriv | CreateViewPriv | ShowViewPriv
+
 // MySQL type maximum length.
 const (
 	// For arguments that have no fixed number of decimals, the decimals value is set to 31,

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -254,7 +254,7 @@ const (
 const AllPrivMask = AllPriv - 1
 
 // GlobalDBVisible is a collection of global privileges which allow user to see all databases name.
-const GlobalDBVisible = CreatePriv | SelectPriv | InsertPriv | UpdatePriv | DeletePriv | ShowDBPriv | DropPriv | AlterPriv | IndexPriv | CreateViewPriv | ShowViewPriv
+const GlobalDBVisible = CreatePriv | SelectPriv | InsertPriv | UpdatePriv | DeletePriv | ShowDBPriv | DropPriv | AlterPriv | IndexPriv | CreateViewPriv | ShowViewPriv | GrantPriv
 
 // MySQL type maximum length.
 const (


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Originally, user with any global privilege can visit any database, this is not compatible with MySQL.

### What is changed and how it works?
Add `GlobalDBVisible` to represent subset of privileges which can access any database

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
