### PR TITLE
Remove abandon command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,3 @@ clean:
 	go clean -i ./...
 	rm -rf *.out
 	rm parser.go
-
-cpmod:
-	cp go.mod1 go.mod && cp go.sum1 go.sum


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

After merging #679, `cpmod` in Makefile is abandon, it should be removed.

### What is changed and how it works?

Removing `cpmod` in Makefile.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - None

Code changes

 - None

Side effects

 - None

Related changes

 - None
