### PR TITLE
add json_objetagg's unsupported second argument type errorcode

### DIFF
--- a/mysql/errcode.go
+++ b/mysql/errcode.go
@@ -1036,6 +1036,7 @@ const (
 	ErrWarnMemoryQuotaOverflow             = 8063
 	ErrWarnOptimizerHintParseError         = 8064
 	ErrWarnOptimizerHintInvalidInteger     = 8065
+	ErrUnsupportedSecondArgumentType       = 8066
 
 	// Error codes used by TiDB ddl package
 	ErrUnsupportedDDLOperation        = 8200

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -1063,7 +1063,7 @@ var MySQLErrName = map[uint16]string{
 	ErrPrivilegeCheckFail:                  "privilege check fail", // this error message should begin lowercased to be compatible with the test
 	ErrInvalidWildCard:                     "Wildcard fields without any table name appears in wrong place",
 	ErrMixOfGroupFuncAndFieldsIncompatible: "In aggregated query without GROUP BY, expression #%d of SELECT list contains nonaggregated column '%s'; this is incompatible with sql_mode=only_full_group_by",
-	ErrUnsupportedSecondArgumentType:       "The second argument type is not supported now, it will be supported later",
+	ErrUnsupportedSecondArgumentType:       "JSON_OBJECTAGG: unsupported second argument type %v",
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout:    "PD server timeout",

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -1063,6 +1063,7 @@ var MySQLErrName = map[uint16]string{
 	ErrPrivilegeCheckFail:                  "privilege check fail", // this error message should begin lowercased to be compatible with the test
 	ErrInvalidWildCard:                     "Wildcard fields without any table name appears in wrong place",
 	ErrMixOfGroupFuncAndFieldsIncompatible: "In aggregated query without GROUP BY, expression #%d of SELECT list contains nonaggregated column '%s'; this is incompatible with sql_mode=only_full_group_by",
+	ErrUnsupportedSecondArgumentType:       "The second argument type is not supported now, it will be supported later",
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout:    "PD server timeout",


### PR DESCRIPTION
In [#11154](https://github.com/pingcap/tidb/pull/11154), when json_objectagg append json which contains string key and any kinds of value to the result chunk, the value type can be any types but appendBinary only support few types, so many types will not supported now in json_objectagg result and I add the error code for this.