### PR TITLE
parser: support expression restored string in default value.

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -81,12 +81,12 @@ const (
 
 // ColumnInfo provides meta data describing of a table column.
 type ColumnInfo struct {
-	ID                  int64               `json:"id"`
-	Name                CIStr               `json:"name"`
-	Offset              int                 `json:"offset"`
-	OriginDefaultValue  interface{}         `json:"origin_default"`
-	DefaultValue        interface{}         `json:"default"`
-	DefaultValueBit     []byte              `json:"default_bit"`
+	ID                 int64       `json:"id"`
+	Name               CIStr       `json:"name"`
+	Offset             int         `json:"offset"`
+	OriginDefaultValue interface{} `json:"origin_default"`
+	DefaultValue       interface{} `json:"default"`
+	DefaultValueBit    []byte      `json:"default_bit"`
 	// DefaultIsExpr is indicates the default value string is expr.
 	DefaultIsExpr       bool                `json:"default_is_expr"`
 	GeneratedExprString string              `json:"generated_expr_string"`

--- a/model/model.go
+++ b/model/model.go
@@ -87,6 +87,8 @@ type ColumnInfo struct {
 	OriginDefaultValue  interface{}         `json:"origin_default"`
 	DefaultValue        interface{}         `json:"default"`
 	DefaultValueBit     []byte              `json:"default_bit"`
+	// DefaultIsExpr is indicates the default value string is expr.
+	DefaultIsExpr       bool                `json:"default_is_expr"`
 	GeneratedExprString string              `json:"generated_expr_string"`
 	GeneratedStored     bool                `json:"generated_stored"`
 	Dependences         map[string]struct{} `json:"dependences"`


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Now the default value in `columnInfo` has been evaluated.
but in some cases, the default value is dynamic, needing to be evaluated every time call it.
It's a little bit like a generated column, so we store the expression restored string in default value.

So we need a field to judge the default string is whether the `common_string` or `expr_string`.

after this pr:
```
create sequence seq
create table t(a int default next value for seq)
```
the `a`'s default value will be a string equal to `"nextval(seq)"`
the  field `DefaultIsExpr` in columnInfo of `a` will be true.

linked TiDB PR:

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has added fields in columnInfo
