### PR TITLE
terror: expose args from Error

### DIFF
--- a/terror/terror.go
+++ b/terror/terror.go
@@ -177,6 +177,11 @@ func (e *Error) Code() ErrCode {
 	return e.code
 }
 
+// Args returns the inner args
+func (e *Error) Args() []interface{} {
+	return e.args
+}
+
 // MarshalJSON implements json.Marshaler interface.
 func (e *Error) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Required by https://github.com/pingcap/tidb/pull/14626, the `args` of `Error` need be exposed.

### What is changed and how it works?

Add a method to `Error` that returns the `args`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No need for tests because it's too trivial.

Code changes

 - Has exported function/method change
