### PR TITLE
parser: add errcode and errname of unsupported sequence default value for column type

### DIFF
--- a/mysql/errcode.go
+++ b/mysql/errcode.go
@@ -1067,6 +1067,7 @@ const (
 	ErrCancelFinishedDDLJob           = 8225
 	ErrCannotCancelDDLJob             = 8226
 	ErrSequenceUnsupportedTableOption = 8227
+	ErrColumnTypeUnsupportedNextValue = 8228
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout    = 9001

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -1047,6 +1047,7 @@ var MySQLErrName = map[uint16]string{
 	ErrWarnOptimizerHintParseError:      "Optimizer hint syntax error at %v",
 
 	ErrSequenceUnsupportedTableOption:      "Unsupported sequence table-option %s",
+	ErrColumnTypeUnsupportedNextValue:      "Unsupported sequence default value for column type '%s'",
 	ErrUnsupportedType:                     "Unsupported type %T",
 	ErrAnalyzeMissIndex:                    "Index '%s' in field list does not exist in table '%s'",
 	ErrCartesianProductUnsupported:         "Cartesian product is unsupported",


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
add errcode and errname for unsupported sequence default value for column type
such as:
```
create sequence seq;
create table t(a char(1) default next value for seq);

result: 
this 2 SQL will execute success even in MariaDB, but we wanna check this.
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to update the documentation
