### PR TITLE
parser: add WEIGHT_STRING() function

### DIFF
--- a/ast/functions.go
+++ b/ast/functions.go
@@ -226,6 +226,7 @@ const (
 	CharLength      = "char_length"
 	CharacterLength = "character_length"
 	FindInSet       = "find_in_set"
+	WeightString    = "weight_string"
 
 	// information functions
 	Benchmark      = "benchmark"
@@ -419,6 +420,21 @@ func (n *FuncCallExpr) Restore(ctx *format.RestoreCtx) error {
 			if err := n.Args[0].Restore(ctx); err != nil {
 				return errors.Annotatef(err, "An error occurred while restore FuncCallExpr.Args[0]")
 			}
+		}
+	case WeightString:
+		if err := n.Args[0].Restore(ctx); err != nil {
+			return errors.Annotatef(err, "An error occurred while restore FuncCallExpr.(WEIGHT_STRING).Args[0]")
+		}
+		if len(n.Args) == 3 {
+			ctx.WritePlain(" ")
+			ctx.WriteKeyWord("AS")
+			ctx.WritePlain(" ")
+			ctx.WriteKeyWord(n.Args[1].(ValueExpr).GetValue().(string))
+			ctx.WritePlain("(")
+			if err := n.Args[2].Restore(ctx); err != nil {
+				return errors.Annotatef(err, "An error occurred while restore FuncCallExpr.(WEIGHT_STRING).Args[2]")
+			}
+			ctx.WritePlain(")")
 		}
 	default:
 		for i, argv := range n.Args {

--- a/ast/functions.go
+++ b/ast/functions.go
@@ -426,9 +426,7 @@ func (n *FuncCallExpr) Restore(ctx *format.RestoreCtx) error {
 			return errors.Annotatef(err, "An error occurred while restore FuncCallExpr.(WEIGHT_STRING).Args[0]")
 		}
 		if len(n.Args) == 3 {
-			ctx.WritePlain(" ")
-			ctx.WriteKeyWord("AS")
-			ctx.WritePlain(" ")
+			ctx.WriteKeyWord(" AS ")
 			ctx.WriteKeyWord(n.Args[1].(ValueExpr).GetValue().(string))
 			ctx.WritePlain("(")
 			if err := n.Args[2].Restore(ctx); err != nil {

--- a/ast/functions_test.go
+++ b/ast/functions_test.go
@@ -84,6 +84,16 @@ func (ts *testFunctionsSuite) TestFuncCallExprRestore(c *C) {
 		{"next value for sequence", "NEXTVAL(`sequence`)"},
 		{"NeXt vAluE for seQuEncE2", "NEXTVAL(`seQuEncE2`)"},
 		{"NeXt vAluE for test.seQuEncE2", "NEXTVAL(`test`.`seQuEncE2`)"},
+		{"weight_string(a)", "WEIGHT_STRING(`a`)"},
+		{"Weight_stRing(test.a)", "WEIGHT_STRING(`test`.`a`)"},
+		{"weight_string('a')", "WEIGHT_STRING('a')"},
+		// TODO(bb7133): collate for literal cannot be restored.
+		//{"weight_string(_utf8 'a' collate utf8_general_ci)", "WEIGHT_STRING(_UTF8'a' COLLATE utf8_general_ci)"},
+		{"weight_string(_utf8 'a')", "WEIGHT_STRING(_UTF8'a')"},
+		{"weight_string(a as char(5))", "WEIGHT_STRING(`a` AS CHAR(5))"},
+		{"weight_string(a as character(5))", "WEIGHT_STRING(`a` AS CHAR(5))"},
+		{"weight_string(a as binary(5))", "WEIGHT_STRING(`a` AS BINARY(5))"},
+		{"hex(weight_string('abc' as binary(5)))", "HEX(WEIGHT_STRING('abc' AS BINARY(5)))"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*SelectStmt).Fields.Fields[0].Expr

--- a/ast/functions_test.go
+++ b/ast/functions_test.go
@@ -87,7 +87,7 @@ func (ts *testFunctionsSuite) TestFuncCallExprRestore(c *C) {
 		{"weight_string(a)", "WEIGHT_STRING(`a`)"},
 		{"Weight_stRing(test.a)", "WEIGHT_STRING(`test`.`a`)"},
 		{"weight_string('a')", "WEIGHT_STRING('a')"},
-		// TODO(bb7133): collate for literal cannot be restored.
+		// TODO(bb7133): collate for literal values cannot be restored.
 		//{"weight_string(_utf8 'a' collate utf8_general_ci)", "WEIGHT_STRING(_UTF8'a' COLLATE utf8_general_ci)"},
 		{"weight_string(_utf8 'a')", "WEIGHT_STRING(_UTF8'a')"},
 		{"weight_string(a as char(5))", "WEIGHT_STRING(`a` AS CHAR(5))"},

--- a/misc.go
+++ b/misc.go
@@ -687,6 +687,7 @@ var tokenMap = map[string]int{
 	"WARNINGS":                 warnings,
 	"ERRORS":                   identSQLErrors,
 	"WEEK":                     week,
+	"WEIGHT_STRING":            weightString,
 	"WHEN":                     when,
 	"WHERE":                    where,
 	"WIDTH":                    width,

--- a/parser.y
+++ b/parser.y
@@ -5883,7 +5883,7 @@ FunctionCallNonKeyword:
 	}
 /** The following syntax is defined in MySQL parser, but not described in MySQL reference manual, we do not support it for now.
 |   weightString '(' Expression ',' LengthNum, ',' LengthNum, ',' LengthNum ')'
-    {
+	{
 	}
 **/
 |	FunctionNameSequence

--- a/parser.y
+++ b/parser.y
@@ -548,6 +548,7 @@ import (
 	bindings              "BINDINGS"
 	warnings              "WARNINGS"
 	without               "WITHOUT"
+	weightString          "WEIGHT_STRING"
 	identSQLErrors        "ERRORS"
 	week                  "WEEK"
 	yearType              "YEAR"
@@ -4718,6 +4719,7 @@ UnReservedKeyword:
 |	"YEAR"
 |	"MODE"
 |	"WEEK"
+|	"WEIGHT_STRING"
 |	"ANY"
 |	"SOME"
 |	"USER"
@@ -5858,6 +5860,32 @@ FunctionCallNonKeyword:
 			Args:   []ast.ExprNode{$6, $4, direction},
 		}
 	}
+|	weightString '(' Expression ')'
+	{
+		$$ = &ast.FuncCallExpr{
+			FnName: model.NewCIStr($1),
+			Args:   []ast.ExprNode{$3},
+		}
+	}
+|	weightString '(' Expression "AS" Char FieldLen ')'
+	{
+		$$ = &ast.FuncCallExpr{
+			FnName: model.NewCIStr($1),
+			Args:   []ast.ExprNode{$3, ast.NewValueExpr("CHAR"), ast.NewValueExpr($6)},
+		}
+	}
+|	weightString '(' Expression "AS" "BINARY" FieldLen ')'
+	{
+		$$ = &ast.FuncCallExpr{
+			FnName: model.NewCIStr($1),
+			Args:   []ast.ExprNode{$3, ast.NewValueExpr("BINARY"), ast.NewValueExpr($6)},
+		}
+	}
+/** The following syntax is defined in MySQL parser, but not described in MySQL reference manual, we do not support it for now.
+|   weightString '(' Expression ',' LengthNum, ',' LengthNum, ',' LengthNum ')'
+    {
+	}
+**/
 |	FunctionNameSequence
 
 GetFormatSelector:

--- a/parser.y
+++ b/parser.y
@@ -5881,11 +5881,6 @@ FunctionCallNonKeyword:
 			Args:   []ast.ExprNode{$3, ast.NewValueExpr("BINARY"), ast.NewValueExpr($6)},
 		}
 	}
-/** The following syntax is defined in MySQL parser, but not described in MySQL reference manual, we do not support it for now.
-|   weightString '(' Expression ',' LengthNum, ',' LengthNum, ',' LengthNum ')'
-	{
-	}
-**/
 |	FunctionNameSequence
 
 GetFormatSelector:


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR is the implementation of `WEIGHT_STRING()` in parser, you can check the [MySQL manual](https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_weight-string) for more details.

Here we only implement a part of the full syntax: `WEIGHT_STRING(str [AS {CHAR|BINARY}(N)])`, according to MySQL manual:

> WEIGHT_STRING() is a debugging function intended for internal use. Its behavior can change without notice between MySQL versions. It can be used for testing and debugging of collations, especially if you are adding a new collation. 

We can adjust this function on our own needs.

Related issue: https://github.com/pingcap/tidb/issues/3580
Related TiDB PR: https://github.com/pingcap/tidb/pull/14792

### What is changed and how it works?
Add `WEIGHT_STRING()` in parser.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation
