### PR TITLE
model: do not rewrite collation id as default for tipb.

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -900,7 +900,7 @@ func IndexToProto(t *TableInfo, idx *IndexInfo) *tipb.IndexInfo {
 func ColumnToProto(c *ColumnInfo) *tipb.ColumnInfo {
 	pc := &tipb.ColumnInfo{
 		ColumnId:  c.ID,
-		Collation: collationToProto(c.FieldType.Collate),
+		Collation: int32(mysql.CollationNames[c.FieldType.Collate]),
 		ColumnLen: int32(c.FieldType.Flen),
 		Decimal:   int32(c.FieldType.Decimal),
 		Flag:      int32(c.Flag),
@@ -908,18 +908,6 @@ func ColumnToProto(c *ColumnInfo) *tipb.ColumnInfo {
 	}
 	pc.Tp = int32(c.FieldType.Tp)
 	return pc
-}
-
-// TODO: update it when more collate is supported.
-func collationToProto(c string) int32 {
-	v := mysql.CollationNames[c]
-	if v == mysql.BinaryDefaultCollationID {
-		return int32(mysql.BinaryDefaultCollationID)
-	}
-	// We only support binary and utf8_bin collation.
-	// Setting other collations to utf8_bin for old data compatibility.
-	// For the data created when we didn't enforce utf8_bin collation in create table.
-	return int32(mysql.DefaultCollationID)
 }
 
 // TableColumnID is composed by table ID and column ID.

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -321,3 +321,44 @@ func (testModelSuite) TestUnmarshalCIStr(c *C) {
 	c.Assert(ci.O, Equals, str)
 	c.Assert(ci.L, Equals, "aabb")
 }
+
+func (*testModelSuite) TestToPB(c *C) {
+	column := &ColumnInfo{
+		ID:           1,
+		Name:         NewCIStr("c"),
+		Offset:       0,
+		DefaultValue: 0,
+		FieldType:    *types.NewFieldType(0),
+		Hidden:       true,
+	}
+	column.Collate = "utf8mb4_general_ci"
+	index := &IndexInfo{
+		Name:  NewCIStr("key"),
+		Table: NewCIStr("t"),
+		Columns: []*IndexColumn{
+			{
+				Name:   NewCIStr("c"),
+				Offset: 0,
+				Length: 10,
+			}},
+		Unique:  true,
+		Primary: true,
+	}
+	fk := &FKInfo{
+		RefCols: []CIStr{NewCIStr("a")},
+		Cols:    []CIStr{NewCIStr("a")},
+	}
+	table := &TableInfo{
+		ID:          1,
+		Name:        NewCIStr("t"),
+		Charset:     "utf8",
+		Collate:     "utf8_bin",
+		Columns:     []*ColumnInfo{column},
+		Indices:     []*IndexInfo{index},
+		ForeignKeys: []*FKInfo{fk},
+		PKIsHandle:  true,
+	}
+	c.Assert(ColumnToProto(column).String(), Equals, "column_id:1 collation:45 columnLen:-1 decimal:-1 ")
+	c.Assert(ColumnsToProto([]*ColumnInfo{column}, false)[0].String(), Equals, "column_id:1 collation:45 columnLen:-1 decimal:-1 ")
+	c.Assert(IndexToProto(table, index).String(), Equals, "table_id:1 columns:<column_id:1 collation:45 columnLen:-1 decimal:-1 > unique:true ")
+}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Remove ColumnToProto() function and do not rewrite the collation ID, since new collations are supported by TiDB now.

### What is changed and how it works?
As stated above.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Breaking backward compatibility

Related changes

 - NA