### PR TITLE
parser: set `UnionStmt` and `ShowStmt` as readonly (#755)

### DIFF
--- a/ast/util.go
+++ b/ast/util.go
@@ -27,7 +27,14 @@ func IsReadOnly(node Node) bool {
 
 		node.Accept(&checker)
 		return checker.readOnly
-	case *ExplainStmt, *DoStmt:
+	case *ExplainStmt, *DoStmt, *ShowStmt:
+		return true
+	case *UnionStmt:
+		for _, sel := range node.(*UnionStmt).SelectList.Selects {
+			if !IsReadOnly(sel) {
+				return false
+			}
+		}
 		return true
 	default:
 		return false

--- a/ast/util_test.go
+++ b/ast/util_test.go
@@ -48,6 +48,44 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 
 	stmt = &DoStmt{}
 	c.Assert(IsReadOnly(stmt), IsTrue)
+
+	stmt = &ShowStmt{}
+	c.Assert(IsReadOnly(stmt), IsTrue)
+
+	stmt = &ShowStmt{}
+	c.Assert(IsReadOnly(stmt), IsTrue)
+}
+
+func (s *testCacheableSuite) TestUnionReadOnly(c *C) {
+	selectReadOnly := &SelectStmt{}
+	selectForUpdate := &SelectStmt{
+		LockTp: SelectLockForUpdate,
+	}
+	selectForUpdateNoWait := &SelectStmt{
+		LockTp: SelectLockForUpdateNoWait,
+	}
+
+	unionStmt := &UnionStmt{
+		SelectList: &UnionSelectList{
+			Selects: []*SelectStmt{selectReadOnly, selectReadOnly},
+		},
+	}
+	c.Assert(IsReadOnly(unionStmt), IsTrue)
+
+	unionStmt.SelectList.Selects = []*SelectStmt{selectReadOnly, selectReadOnly, selectReadOnly}
+	c.Assert(IsReadOnly(unionStmt), IsTrue)
+
+	unionStmt.SelectList.Selects = []*SelectStmt{selectReadOnly, selectForUpdate}
+	c.Assert(IsReadOnly(unionStmt), IsFalse)
+
+	unionStmt.SelectList.Selects = []*SelectStmt{selectReadOnly, selectForUpdateNoWait}
+	c.Assert(IsReadOnly(unionStmt), IsFalse)
+
+	unionStmt.SelectList.Selects = []*SelectStmt{selectForUpdate, selectForUpdateNoWait}
+	c.Assert(IsReadOnly(unionStmt), IsFalse)
+
+	unionStmt.SelectList.Selects = []*SelectStmt{selectReadOnly, selectForUpdate, selectForUpdateNoWait}
+	c.Assert(IsReadOnly(unionStmt), IsFalse)
 }
 
 // CleanNodeText set the text of node and all child node empty.


### PR DESCRIPTION
Conflicting files:
util.go
util_test.go

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tidb/issues/15050.
`UNION` statement and `SHOW` statement are not treated as readonly statement. These statements are executed again in retrying transactions.

### What is changed and how it works?
Set `UnionStmt` and `ShowStmt` as readonly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note

Release Note

 - Treat `UNION` statement and `SHOW` statement as readonly statements.