### PR TITLE
parser: set text for explainable statements

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -11688,6 +11688,8 @@ yynewstate:
 				Stmt:   yyS[yypt-0].statement,
 				Format: "row",
 			}
+			startOffset := parser.startOffset(&yyS[yypt])
+			yyS[yypt-0].statement.SetText(string(parser.src[startOffset:]))
 		}
 	case 400:
 		{
@@ -11709,6 +11711,8 @@ yynewstate:
 				Stmt:   yyS[yypt-0].statement,
 				Format: yyS[yypt-1].ident,
 			}
+			startOffset := parser.startOffset(&yyS[yypt])
+			yyS[yypt-0].statement.SetText(string(parser.src[startOffset:]))
 		}
 	case 403:
 		{
@@ -11723,6 +11727,8 @@ yynewstate:
 				Stmt:   yyS[yypt-0].statement,
 				Format: yyS[yypt-1].item.(string),
 			}
+			startOffset := parser.startOffset(&yyS[yypt])
+			yyS[yypt-0].statement.SetText(string(parser.src[startOffset:]))
 		}
 	case 405:
 		{
@@ -11731,6 +11737,8 @@ yynewstate:
 				Format:  "row",
 				Analyze: true,
 			}
+			startOffset := parser.startOffset(&yyS[yypt])
+			yyS[yypt-0].statement.SetText(string(parser.src[startOffset:]))
 		}
 	case 406:
 		{

--- a/parser.y
+++ b/parser.y
@@ -3974,6 +3974,8 @@ ExplainStmt:
 			Stmt:   $2,
 			Format: "row",
 		}
+		startOffset := parser.startOffset(&yyS[yypt])
+		$2.SetText(string(parser.src[startOffset:]))
 	}
 |	ExplainSym "FOR" "CONNECTION" NUM
 	{
@@ -3995,6 +3997,8 @@ ExplainStmt:
 			Stmt:   $5,
 			Format: $4,
 		}
+		startOffset := parser.startOffset(&yyS[yypt])
+		$5.SetText(string(parser.src[startOffset:]))
 	}
 |	ExplainSym "FORMAT" "=" ExplainFormatType "FOR" "CONNECTION" NUM
 	{
@@ -4009,6 +4013,8 @@ ExplainStmt:
 			Stmt:   $5,
 			Format: $4.(string),
 		}
+		startOffset := parser.startOffset(&yyS[yypt])
+		$5.SetText(string(parser.src[startOffset:]))
 	}
 |	ExplainSym "ANALYZE" ExplainableStmt
 	{
@@ -4017,6 +4023,8 @@ ExplainStmt:
 			Format:  "row",
 			Analyze: true,
 		}
+		startOffset := parser.startOffset(&yyS[yypt])
+		$3.SetText(string(parser.src[startOffset:]))
 	}
 
 ExplainFormatType:

--- a/parser_test.go
+++ b/parser_test.go
@@ -5000,3 +5000,19 @@ func (s *testParserSuite) TestIndexAdviseStmt(c *C) {
 
 	s.RunTest(c, table)
 }
+
+func (s *testParserSuite) TestExplainStmtText(c *C) {
+	parser := parser.New()
+	sqls := []string{
+		"explain select a from t",
+		"explain format = 'row' select a from t",
+		"explain format = traditional select a from t",
+		"explain analyze select a from t",
+	}
+	for _, sql := range sqls {
+		stmts, _, err := parser.Parse(sql, "", "")
+		c.Assert(err, IsNil)
+		explain := stmts[0].(*ast.ExplainStmt)
+		c.Assert(explain.Stmt.Text(), Equals, "select a from t")
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

SPM in TiDB uses the `Text()` method of `SelectStmt` in `ExplainStmt` to do pattern matching, but this field is empty now.

### What is changed and how it works?

Call `SetText()` for those explainable statements.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

N/A

Related changes

N/A
