### PR TITLE
digest: fix '/' in normalizing SQL

### DIFF
--- a/digester_test.go
+++ b/digester_test.go
@@ -51,6 +51,7 @@ func (s *testSQLDigestSuite) TestNormalize(c *C) {
 		{"select * from t ignore index(", "select * from t ignore index"},
 		{"select /*+ ", "select "},
 		{"select * from 🥳", "select * from"},
+		{"select 1 / 2", "select ? / ?"},
 	}
 	for _, test := range tests {
 		normalized := parser.Normalize(test.input)

--- a/lexer.go
+++ b/lexer.go
@@ -339,6 +339,7 @@ func startWithSlash(s *Scanner) (tok int, pos Pos, lit string) {
 	s.r.inc()
 	if s.r.peek() != '*' {
 		tok = int('/')
+		lit = "/"
 		return
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
There's a bug in normalizing SQL. '/' is not shown in normalized SQL.
Normalize `select 1 / 2`.
Before:  `select ? ?`
After: `select ? / ?`

### What is changed and how it works?
`lit` is not set when scanning '/'. Now it's set.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note

Release Note
 - Fix the bug that '/' is not shown in the normalized SQL.
 - Compatibility problem: Digests in slow log is not matched after upgrading TiDB.