### PR TITLE
opcode,ast: fix invalid restore of '4 DIV 2' (became '4DIV2')

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -156,19 +156,27 @@ type BinaryOperationExpr struct {
 	R ExprNode
 }
 
+func restoreBinaryOpWithSpacesAround(ctx *format.RestoreCtx, op opcode.Op) error {
+	shouldInsertSpace := ctx.Flags.HasSpacesAroundBinaryOperationFlag() || op.IsKeyword()
+	if shouldInsertSpace {
+		ctx.WritePlain(" ")
+	}
+	if err := op.Restore(ctx); err != nil {
+		return err // no need to annotate, the caller will annotate.
+	}
+	if shouldInsertSpace {
+		ctx.WritePlain(" ")
+	}
+	return nil
+}
+
 // Restore implements Node interface.
 func (n *BinaryOperationExpr) Restore(ctx *format.RestoreCtx) error {
 	if err := n.L.Restore(ctx); err != nil {
 		return errors.Annotate(err, "An error occurred when restore BinaryOperationExpr.L")
 	}
-	if ctx.Flags.HasSpacesAroundBinaryOperationFlag() {
-		ctx.WritePlain(" ")
-	}
-	if err := n.Op.Restore(ctx); err != nil {
+	if err := restoreBinaryOpWithSpacesAround(ctx, n.Op); err != nil {
 		return errors.Annotate(err, "An error occurred when restore BinaryOperationExpr.Op")
-	}
-	if ctx.Flags.HasSpacesAroundBinaryOperationFlag() {
-		ctx.WritePlain(" ")
 	}
 	if err := n.R.Restore(ctx); err != nil {
 		return errors.Annotate(err, "An error occurred when restore BinaryOperationExpr.R")
@@ -406,7 +414,7 @@ func (n *CompareSubqueryExpr) Restore(ctx *format.RestoreCtx) error {
 	if err := n.L.Restore(ctx); err != nil {
 		return errors.Annotate(err, "An error occurred while restore CompareSubqueryExpr.L")
 	}
-	if err := n.Op.Restore(ctx); err != nil {
+	if err := restoreBinaryOpWithSpacesAround(ctx, n.Op); err != nil {
 		return errors.Annotate(err, "An error occurred while restore CompareSubqueryExpr.Op")
 	}
 	if n.All {

--- a/ast/expressions_test.go
+++ b/ast/expressions_test.go
@@ -109,6 +109,8 @@ func (tc *testExpressionsSuite) TestUnaryOperationExprRestore(c *C) {
 		{"--1", "--1"},
 		{"-+1", "-+1"},
 		{"-1", "-1"},
+		{"not true", "!TRUE"},
+		{"~3", "~3"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*SelectStmt).Fields.Fields[0].Expr
@@ -194,6 +196,16 @@ func (tc *testExpressionsSuite) TestBinaryOperationExpr(c *C) {
 		{"3-5", "3-5"},
 		{"a<>5", "`a`!=5"},
 		{"a=1", "`a`=1"},
+		{"a mod 2", "`a`%2"},
+		{"a div 2", "`a` DIV 2"},
+		{"true and true", "TRUE AND TRUE"},
+		{"false or false", "FALSE OR FALSE"},
+		{"true xor false", "TRUE XOR FALSE"},
+		{"3 & 4", "3&4"},
+		{"5 | 6", "5|6"},
+		{"7 ^ 8", "7^8"},
+		{"9 << 10", "9<<10"},
+		{"11 >> 12", "11>>12"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*SelectStmt).Fields.Fields[0].Expr

--- a/opcode/opcode.go
+++ b/opcode/opcode.go
@@ -14,10 +14,8 @@
 package opcode
 
 import (
-	"fmt"
 	"io"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/format"
 )
 
@@ -58,93 +56,185 @@ const (
 	IsFalsity
 )
 
-// Ops maps opcode to string.
-var Ops = map[Op]string{
-	LogicAnd:   "and",
-	LogicOr:    "or",
-	LogicXor:   "xor",
-	LeftShift:  "leftshift",
-	RightShift: "rightshift",
-	GE:         "ge",
-	LE:         "le",
-	EQ:         "eq",
-	NE:         "ne",
-	LT:         "lt",
-	GT:         "gt",
-	Plus:       "plus",
-	Minus:      "minus",
-	And:        "bitand",
-	Or:         "bitor",
-	Mod:        "mod",
-	Xor:        "bitxor",
-	Div:        "div",
-	Mul:        "mul",
-	Not:        "not",
-	BitNeg:     "bitneg",
-	IntDiv:     "intdiv",
-	NullEQ:     "nulleq",
-	In:         "in",
-	Like:       "like",
-	Case:       "case",
-	Regexp:     "regexp",
-	IsNull:     "isnull",
-	IsTruth:    "istrue",
-	IsFalsity:  "isfalse",
+var ops = [...]struct {
+	name      string
+	literal   string
+	isKeyword bool
+}{
+	LogicAnd: {
+		name:      "and",
+		literal:   "AND",
+		isKeyword: true,
+	},
+	LogicOr: {
+		name:      "or",
+		literal:   "OR",
+		isKeyword: true,
+	},
+	LogicXor: {
+		name:      "xor",
+		literal:   "XOR",
+		isKeyword: true,
+	},
+	LeftShift: {
+		name:      "leftshift",
+		literal:   "<<",
+		isKeyword: false,
+	},
+	RightShift: {
+		name:      "rightshift",
+		literal:   ">>",
+		isKeyword: false,
+	},
+	GE: {
+		name:      "ge",
+		literal:   ">=",
+		isKeyword: false,
+	},
+	LE: {
+		name:      "le",
+		literal:   "<=",
+		isKeyword: false,
+	},
+	EQ: {
+		name:      "eq",
+		literal:   "=",
+		isKeyword: false,
+	},
+	NE: {
+		name:      "ne",
+		literal:   "!=", // perhaps should use `<>` here
+		isKeyword: false,
+	},
+	LT: {
+		name:      "lt",
+		literal:   "<",
+		isKeyword: false,
+	},
+	GT: {
+		name:      "gt",
+		literal:   ">",
+		isKeyword: false,
+	},
+	Plus: {
+		name:      "plus",
+		literal:   "+",
+		isKeyword: false,
+	},
+	Minus: {
+		name:      "minus",
+		literal:   "-",
+		isKeyword: false,
+	},
+	And: {
+		name:      "bitand",
+		literal:   "&",
+		isKeyword: false,
+	},
+	Or: {
+		name:      "bitor",
+		literal:   "|",
+		isKeyword: false,
+	},
+	Mod: {
+		name:      "mod",
+		literal:   "%",
+		isKeyword: false,
+	},
+	Xor: {
+		name:      "bitxor",
+		literal:   "^",
+		isKeyword: false,
+	},
+	Div: {
+		name:      "div",
+		literal:   "/",
+		isKeyword: false,
+	},
+	Mul: {
+		name:      "mul",
+		literal:   "*",
+		isKeyword: false,
+	},
+	Not: {
+		name:      "not",
+		literal:   "!", // perhaps should use `NOT` here.
+		isKeyword: false,
+	},
+	BitNeg: {
+		name:      "bitneg",
+		literal:   "~",
+		isKeyword: false,
+	},
+	IntDiv: {
+		name:      "intdev",
+		literal:   "DIV",
+		isKeyword: true,
+	},
+	NullEQ: {
+		name:      "nulleq",
+		literal:   "<=>",
+		isKeyword: false,
+	},
+	In: {
+		name:      "in",
+		literal:   "IN",
+		isKeyword: true,
+	},
+	Like: {
+		name:      "like",
+		literal:   "LIKE",
+		isKeyword: true,
+	},
+	Case: {
+		name:      "case",
+		literal:   "CASE",
+		isKeyword: true,
+	},
+	Regexp: {
+		name:      "regexp",
+		literal:   "REGEXP",
+		isKeyword: true,
+	},
+	IsNull: {
+		name:      "isnull",
+		literal:   "IS NULL",
+		isKeyword: true,
+	},
+	IsTruth: {
+		name:      "istrue",
+		literal:   "IS TRUE",
+		isKeyword: true,
+	},
+	IsFalsity: {
+		name:      "isfalse",
+		literal:   "IS FALSE",
+		isKeyword: true,
+	},
 }
 
 // String implements Stringer interface.
 func (o Op) String() string {
-	str, ok := Ops[o]
-	if !ok {
-		panic(fmt.Sprintf("%d", o))
-	}
-
-	return str
-}
-
-var opsLiteral = map[Op]string{
-	LogicAnd:   " AND ",
-	LogicOr:    " OR ",
-	LogicXor:   " XOR ",
-	LeftShift:  "<<",
-	RightShift: ">>",
-	GE:         ">=",
-	LE:         "<=",
-	EQ:         "=",
-	NE:         "!=",
-	LT:         "<",
-	GT:         ">",
-	Plus:       "+",
-	Minus:      "-",
-	And:        "&",
-	Or:         "|",
-	Mod:        "%",
-	Xor:        "^",
-	Div:        "/",
-	Mul:        "*",
-	Not:        "!",
-	BitNeg:     "~",
-	IntDiv:     "DIV",
-	NullEQ:     "<=>",
-	In:         "IN",
-	Like:       "LIKE",
-	Case:       "CASE",
-	Regexp:     "REGEXP",
-	IsNull:     "IS NULL",
-	IsTruth:    "IS TRUE",
-	IsFalsity:  "IS FALSE",
+	return ops[o].name
 }
 
 // Format the ExprNode into a Writer.
 func (o Op) Format(w io.Writer) {
-	fmt.Fprintf(w, "%s", opsLiteral[o])
+	io.WriteString(w, ops[o].literal)
+}
+
+// IsKeyword returns whether the operator is a keyword.
+func (o Op) IsKeyword() bool {
+	return ops[o].isKeyword
 }
 
 // Restore the Op into a Writer
 func (o Op) Restore(ctx *format.RestoreCtx) error {
-	if v, ok := opsLiteral[o]; ok {
-		ctx.WriteKeyWord(v)
-		return nil
+	info := &ops[o]
+	if info.isKeyword {
+		ctx.WriteKeyWord(info.literal)
+	} else {
+		ctx.WritePlain(info.literal)
 	}
-	return errors.Errorf("Invalid opcode type %d during restoring AST to SQL text", o)
+	return nil
 }

--- a/opcode/opcode.go
+++ b/opcode/opcode.go
@@ -167,7 +167,7 @@ var ops = [...]struct {
 		isKeyword: false,
 	},
 	IntDiv: {
-		name:      "intdev",
+		name:      "intdiv",
 		literal:   "DIV",
 		isKeyword: true,
 	},

--- a/opcode/opcode_test.go
+++ b/opcode/opcode_test.go
@@ -24,13 +24,11 @@ func TestT(t *testing.T) {
 		t.Fatalf("invalid op code")
 	}
 
-	if len(Ops) != len(opsLiteral) {
-		t.Error("inconsistent count ops and opsliteral")
-	}
 	var buf bytes.Buffer
-	for op := range Ops {
+	for i := range ops {
+		op := Op(i)
 		op.Format(&buf)
-		if buf.String() != opsLiteral[op] {
+		if buf.String() != ops[op].literal {
 			t.Error("format op fail", op)
 		}
 		buf.Reset()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

It was found that in pingcap/tidb#15948 the Restore() involving the `DIV` operator was incorrect: `4 DIV 2` by default was restored without spaces as `4DIV2`.

### What is changed and how it works?

Here we refactored the `opcode` module to include whether the operator is a keyword. Spaces around keyword-like ops are enforced.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change
    * I don't know why the map `opcode.Ops` was exported. It is used nowhere. This PR makes it private.

Side effects

Related changes

 - Need to cherry-pick to the release branch
    * needs to cherry-pick to all previous releases.