### PR TITLE
charset: return a default value for GetCollationByName("")

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -170,6 +170,9 @@ func GetCollations() []*Collation {
 }
 
 func GetCollationByName(name string) (*Collation, error) {
+	if name == "" {
+		name = mysql.DefaultCollationName
+	}
 	collation, ok := collationsNameMap[strings.ToLower(name)]
 	if !ok {
 		return nil, ErrUnknownCollation.GenWithStackByArgs(name)

--- a/charset/charset_test.go
+++ b/charset/charset_test.go
@@ -161,6 +161,10 @@ func (s *testCharsetSuite) TestGetCollationByName(c *C) {
 
 	_, err := GetCollationByName("non_exist")
 	c.Assert(err, ErrorMatches, "\\[ddl:1273\\]Unknown collation: 'non_exist'")
+
+	collation, err := GetCollationByName("")
+	c.Assert(err, IsNil)
+	c.Assert(collation.CharsetName, Equals, "utf8mb4")
 }
 
 func BenchmarkGetCharsetDesc(b *testing.B) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

I see a annoying error log in TiDB like this:

> [2020/04/09 22:26:46.422 +08:00] [ERROR] [terror.go:366] ["encountered error"] [error="[ddl:1273]Unknown collation: ''"] 

and it's caused by here

https://github.com/pingcap/tidb/blob/2a2bf377aed3bc16ce5873a30f4c6d9b15dc6c0e/executor/simple.go#L533

Maybe return a default value is better for `GetCollationByName("")`.

### What is changed and how it works?

Let `GetCollationByName("")` return a default value.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
