### PR TITLE
parser: add new ddl action AlterIndexVisibility

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -2245,7 +2245,7 @@ type AlterTableSpec struct {
 
 	Tp              AlterTableType
 	Name            string
-	KeyName         model.CIStr
+	IndexName       model.CIStr
 	Constraint      *Constraint
 	Options         []*TableOption
 	OrderByList     []*AlterOrderItem
@@ -2702,7 +2702,7 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord("DISCARD TABLESPACE")
 	case AlterTableIndexInvisible:
 		ctx.WriteKeyWord("ALTER INDEX ")
-		ctx.WriteName(n.KeyName.O)
+		ctx.WriteName(n.IndexName.O)
 		switch n.Visibility {
 		case IndexVisibilityVisible:
 			ctx.WriteKeyWord(" VISIBLE")

--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -2245,6 +2245,7 @@ type AlterTableSpec struct {
 
 	Tp              AlterTableType
 	Name            string
+	KeyName         model.CIStr
 	Constraint      *Constraint
 	Options         []*TableOption
 	OrderByList     []*AlterOrderItem
@@ -2701,7 +2702,7 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord("DISCARD TABLESPACE")
 	case AlterTableIndexInvisible:
 		ctx.WriteKeyWord("ALTER INDEX ")
-		ctx.WriteName(n.Name)
+		ctx.WriteName(n.KeyName.O)
 		switch n.Visibility {
 		case IndexVisibilityVisible:
 			ctx.WriteKeyWord(" VISIBLE")

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -70,6 +70,7 @@ const (
 	ActionDropColumns                   ActionType = 38
 	ActionModifyTableAutoIdCache        ActionType = 39
 	ActionRebaseAutoRandomBase          ActionType = 40
+	ActionAlterIndexVisibility          ActionType = 41
 )
 
 const (
@@ -119,6 +120,7 @@ var actionMap = map[ActionType]string{
 	ActionDropColumns:                   "drop multi-columns",
 	ActionModifyTableAutoIdCache:        "modify auto id cache",
 	ActionRebaseAutoRandomBase:          "rebase auto_random ID",
+	ActionAlterIndexVisibility:          "alter index visibility",
 }
 
 // String return current ddl action in string

--- a/parser.go
+++ b/parser.go
@@ -10326,7 +10326,7 @@ yynewstate:
 		{
 			parser.yyVAL.item = &ast.AlterTableSpec{
 				Tp:         ast.AlterTableIndexInvisible,
-				KeyName:    model.NewCIStr(yyS[yypt-1].ident),
+				IndexName:  model.NewCIStr(yyS[yypt-1].ident),
 				Visibility: yyS[yypt-0].item.(ast.IndexVisibility),
 			}
 		}

--- a/parser.go
+++ b/parser.go
@@ -10326,7 +10326,7 @@ yynewstate:
 		{
 			parser.yyVAL.item = &ast.AlterTableSpec{
 				Tp:         ast.AlterTableIndexInvisible,
-				Name:       yyS[yypt-1].ident,
+				KeyName:    model.NewCIStr(yyS[yypt-1].ident),
 				Visibility: yyS[yypt-0].item.(ast.IndexVisibility),
 			}
 		}

--- a/parser.y
+++ b/parser.y
@@ -1860,7 +1860,7 @@ AlterTableSpec:
 	{
 		$$ = &ast.AlterTableSpec{
 			Tp:         ast.AlterTableIndexInvisible,
-			Name:       $3,
+			KeyName:    model.NewCIStr($3),
 			Visibility: $4.(ast.IndexVisibility),
 		}
 	}

--- a/parser.y
+++ b/parser.y
@@ -1860,7 +1860,7 @@ AlterTableSpec:
 	{
 		$$ = &ast.AlterTableSpec{
 			Tp:         ast.AlterTableIndexInvisible,
-			KeyName:    model.NewCIStr($3),
+			IndexName:  model.NewCIStr($3),
 			Visibility: $4.(ast.IndexVisibility),
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

For support `alter table ... alter index ... invisible` statement, we add a new DDL action `AlterIndexVisibility`.

### What is changed and how it works?

- [x] Add a new DDL action `Enum`
- [x] Add a new field `KeyName` (`model.CIStr`) in struct `AlterTableSpec`, it will replace the `Name` (`string`) field in future PR.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects

 - None

Related changes

 - None