### PR TITLE
types: Update `FieldType.Equal` safety.

### DIFF
--- a/types/field_type.go
+++ b/types/field_type.go
@@ -60,13 +60,13 @@ func (ft *FieldType) Clone() *FieldType {
 func (ft *FieldType) Equal(other *FieldType) bool {
 	// We do not need to compare whole `ft.Flag == other.Flag` when wrapping cast upon an Expression.
 	// but need compare unsigned_flag of ft.Flag.
-	// When tp is float or double, do not check whether flen is equal,
-	// because flen for them is only used to distinguish float and double.
+	// When Tp is float or double with Decimal unspecified, do not check whether Flen is equal,
+	// because Flen for them is useless.
 	partialEqual := ft.Tp == other.Tp &&
-		(ft.Flen == other.Flen || ft.EvalType() == ETReal) &&
 		ft.Decimal == other.Decimal &&
 		ft.Charset == other.Charset &&
 		ft.Collate == other.Collate &&
+		(ft.Flen == other.Flen || (ft.EvalType() == ETReal && ft.Decimal == UnspecifiedLength)) &&
 		mysql.HasUnsignedFlag(ft.Flag) == mysql.HasUnsignedFlag(other.Flag)
 	if !partialEqual || len(ft.Elems) != len(other.Elems) {
 		return false

--- a/types/field_type_test.go
+++ b/types/field_type_test.go
@@ -240,3 +240,31 @@ func (s *testFieldTypeSuite) TestHasCharsetFromStmt(c *C) {
 		c.Assert(HasCharset(col.Tp), Equals, t.hasCharset)
 	}
 }
+
+func (s *testFieldTypeSuite) TestFieldTypeEqual(c *C) {
+
+	// Tp not equal
+	ft1 := NewFieldType(mysql.TypeDouble)
+	ft2 := NewFieldType(mysql.TypeFloat)
+	c.Assert(ft1.Equal(ft2), Equals, false)
+
+	// Decimal not equal
+	ft2 = NewFieldType(mysql.TypeDouble)
+	ft2.Decimal = 5
+	c.Assert(ft1.Equal(ft2), Equals, false)
+
+	// Flen not equal and decimal not -1
+	ft1.Decimal = 5
+	ft1.Flen = 22
+	c.Assert(ft1.Equal(ft2), Equals, false)
+
+	// Flen equal
+	ft2.Flen = 22
+	c.Assert(ft1.Equal(ft2), Equals, true)
+
+	// Decimal is -1
+	ft1.Decimal = -1
+	ft2.Decimal = -1
+	ft1.Flen = 23
+	c.Assert(ft1.Equal(ft2), Equals, true)
+}


### PR DESCRIPTION
### What is changed and how it works?

This pr is a subsequent modification of [parser/pull/832](https://github.com/pingcap/parser/pull/832).

We find that when `Decimal` is specified, `Flen` will have a specific effect, see [floating-point-types](https://dev.mysql.com/doc/refman/5.7/en/floating-point-types.html).

Current judgments can also cause problems.

This pr fixes it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change
