### PR TITLE
parser: add order by clause in group_concat (#813)

### DIFF
--- a/ast/functions.go
+++ b/ast/functions.go
@@ -639,6 +639,8 @@ type AggregateFuncExpr struct {
 	// For example, column c1 values are "1", "2", "2",  "sum(c1)" is "5",
 	// but "sum(distinct c1)" is "3".
 	Distinct bool
+	// Order is only used in GROUP_CONCAT
+	Order *OrderByClause
 }
 
 // Restore implements Node interface.
@@ -656,6 +658,12 @@ func (n *AggregateFuncExpr) Restore(ctx *RestoreCtx) error {
 			}
 			if err := n.Args[i].Restore(ctx); err != nil {
 				return errors.Annotatef(err, "An error occurred while restore AggregateFuncExpr.Args[%d]", i)
+			}
+		}
+		if n.Order != nil {
+			ctx.WritePlain(" ")
+			if err := n.Order.Restore(ctx); err != nil {
+				return errors.Annotate(err, "An error occur while restore AggregateFuncExpr.Args Order")
 			}
 		}
 		ctx.WriteKeyWord(" SEPARATOR ")
@@ -694,6 +702,13 @@ func (n *AggregateFuncExpr) Accept(v Visitor) (Node, bool) {
 			return n, false
 		}
 		n.Args[i] = node.(ExprNode)
+	}
+	if n.Order != nil {
+		node, ok := n.Order.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.Order = node.(*OrderByClause)
 	}
 	return v.Leave(n)
 }

--- a/ast/functions_test.go
+++ b/ast/functions_test.go
@@ -117,6 +117,10 @@ func (ts *testFunctionsSuite) TestAggregateFuncExprRestore(c *C) {
 		{"VAR_POP(test_score)", "VAR_POP(`test_score`)"},
 		{"VAR_SAMP(test_score)", "VAR_SAMP(`test_score`)"},
 		{"VARIANCE(test_score)", "VAR_POP(`test_score`)"},
+		{"GROUP_CONCAT(a)", "GROUP_CONCAT(`a` SEPARATOR ',')"},
+		{"GROUP_CONCAT(a separator '--')", "GROUP_CONCAT(`a` SEPARATOR '--')"},
+		{"GROUP_CONCAT(a order by b desc, c)", "GROUP_CONCAT(`a` ORDER BY `b` DESC,`c` SEPARATOR ',')"},
+		{"GROUP_CONCAT(a order by b desc, c separator '--')", "GROUP_CONCAT(`a` ORDER BY `b` DESC,`c` SEPARATOR '--')"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*SelectStmt).Fields.Fields[0].Expr

--- a/parser.go
+++ b/parser.go
@@ -11122,7 +11122,11 @@ yynewstate:
 		{
 			args := yyS[yypt-3].item.([]ast.ExprNode)
 			args = append(args, yyS[yypt-1].item.(ast.ExprNode))
-			parser.yyVAL.expr = &ast.AggregateFuncExpr{F: yyS[yypt-6].ident, Args: args, Distinct: yyS[yypt-4].item.(bool)}
+			agg := &ast.AggregateFuncExpr{F: yyS[yypt-6].ident, Args: args, Distinct: yyS[yypt-4].item.(bool)}
+			if yyS[yypt-2].item != nil {
+				agg.Order = yyS[yypt-2].item.(*ast.OrderByClause)
+			}
+			parser.yyVAL.expr = agg
 		}
 	case 922:
 		{

--- a/parser.y
+++ b/parser.y
@@ -4751,7 +4751,11 @@ SumExpr:
 	{
 		args := $4.([]ast.ExprNode)
 		args = append(args, $6.(ast.ExprNode))
-		$$ = &ast.AggregateFuncExpr{F: $1, Args: args, Distinct: $3.(bool)}
+		agg := &ast.AggregateFuncExpr{F: $1, Args: args, Distinct: $3.(bool)}
+		if $5 != nil {
+			agg.Order = $5.(*ast.OrderByClause)
+		}
+		$$ = agg
 	}
 |	builtinMax '(' BuggyDefaultFalseDistinctOpt Expression ')'  OptWindowingClause
 	{

--- a/parser_test.go
+++ b/parser_test.go
@@ -1583,7 +1583,7 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{`select group_concat(c2,c1 SEPARATOR ';') from t group by c1;`, true, "SELECT GROUP_CONCAT(`c2`, `c1` SEPARATOR ';') FROM `t` GROUP BY `c1`"},
 		{`select group_concat(distinct c2,c1) from t group by c1;`, true, "SELECT GROUP_CONCAT(DISTINCT `c2`, `c1` SEPARATOR ',') FROM `t` GROUP BY `c1`"},
 		{`select group_concat(distinctrow c2,c1) from t group by c1;`, true, "SELECT GROUP_CONCAT(DISTINCT `c2`, `c1` SEPARATOR ',') FROM `t` GROUP BY `c1`"},
-		{`SELECT student_name, GROUP_CONCAT(DISTINCT test_score ORDER BY test_score DESC SEPARATOR ' ') FROM student GROUP BY student_name;`, true, "SELECT `student_name`,GROUP_CONCAT(DISTINCT `test_score` SEPARATOR ' ') FROM `student` GROUP BY `student_name`"},
+		{`SELECT student_name, GROUP_CONCAT(DISTINCT test_score ORDER BY test_score DESC SEPARATOR ' ') FROM student GROUP BY student_name;`, true, "SELECT `student_name`,GROUP_CONCAT(DISTINCT `test_score` ORDER BY `test_score` DESC SEPARATOR ' ') FROM `student` GROUP BY `student_name`"},
 		{`select std(c1), std(all c1), std(distinct c1) from t`, true, "SELECT STD(`c1`),STD(`c1`),STD(DISTINCT `c1`) FROM `t`"},
 		{`select std(c1, c2) from t`, false, ""},
 		{`select stddev(c1), stddev(all c1), stddev(distinct c1) from t`, true, "SELECT STDDEV(`c1`),STDDEV(`c1`),STDDEV(DISTINCT `c1`) FROM `t`"},


### PR DESCRIPTION
Cherry-pick https://github.com/pingcap/parser/pull/813

---

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

part of https://github.com/pingcap/tidb/issues/6838

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 

Code changes

 - Has exported variable/fields change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch

