### PR TITLE
support the syntax insert into tbl_name partition

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -1371,7 +1371,8 @@ type InsertStmt struct {
 	OnDuplicate []*Assignment
 	Select      ResultSetNode
 	// TableHints represents the table level Optimizer Hint for join type.
-	TableHints []*TableOptimizerHint
+	TableHints     []*TableOptimizerHint
+	PartitionNames []model.CIStr
 }
 
 // Restore implements Node interface.
@@ -1404,6 +1405,15 @@ func (n *InsertStmt) Restore(ctx *format.RestoreCtx) error {
 	ctx.WriteKeyWord("INTO ")
 	if err := n.Table.Restore(ctx); err != nil {
 		return errors.Annotate(err, "An error occurred while restore InsertStmt.Table")
+	}
+	if len(n.PartitionNames) != 0 {
+		ctx.WritePlain(" partition(")
+		ctx.WriteName(n.PartitionNames[0].String())
+		for i := 1; i < len(n.PartitionNames); i++ {
+			ctx.WritePlain(", ")
+			ctx.WriteName(n.PartitionNames[i].String())
+		}
+		ctx.WritePlain(")")
 	}
 	if n.Columns != nil {
 		ctx.WritePlain(" (")

--- a/parser.y
+++ b/parser.y
@@ -5281,20 +5281,21 @@ NotKeywordToken:
  *  TODO: support PARTITION
  **********************************************************************************/
 InsertIntoStmt:
-	"INSERT" TableOptimizerHints PriorityOpt IgnoreOptional IntoOpt TableName InsertValues OnDuplicateKeyUpdate
+	"INSERT" TableOptimizerHints PriorityOpt IgnoreOptional IntoOpt TableName PartitionNameListOpt InsertValues OnDuplicateKeyUpdate
 	{
-		x := $7.(*ast.InsertStmt)
+		x := $8.(*ast.InsertStmt)
 		x.Priority = $3.(mysql.PriorityEnum)
 		x.IgnoreErr = $4.(bool)
 		// Wraps many layers here so that it can be processed the same way as select statement.
 		ts := &ast.TableSource{Source: $6.(*ast.TableName)}
 		x.Table = &ast.TableRefsClause{TableRefs: &ast.Join{Left: ts}}
-		if $8 != nil {
-			x.OnDuplicate = $8.([]*ast.Assignment)
+		if $9 != nil {
+			x.OnDuplicate = $9.([]*ast.Assignment)
 		}
 		if $2 != nil {
 			x.TableHints = $2.([]*ast.TableOptimizerHint)
 		}
+		x.PartitionNames = $7.([]model.CIStr)
 		$$ = x
 	}
 
@@ -5428,13 +5429,14 @@ OnDuplicateKeyUpdate:
  *  TODO: support PARTITION
  **********************************************************************************/
 ReplaceIntoStmt:
-	"REPLACE" PriorityOpt IntoOpt TableName InsertValues
+	"REPLACE" PriorityOpt IntoOpt TableName PartitionNameListOpt InsertValues
 	{
-		x := $5.(*ast.InsertStmt)
+		x := $6.(*ast.InsertStmt)
 		x.IsReplace = true
 		x.Priority = $2.(mysql.PriorityEnum)
 		ts := &ast.TableSource{Source: $4.(*ast.TableName)}
 		x.Table = &ast.TableRefsClause{TableRefs: &ast.Join{Left: ts}}
+		x.PartitionNames = $5.([]model.CIStr)
 		$$ = x
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -421,6 +421,8 @@ func (s *testParserSuite) TestDMLStmt(c *C) {
 		{"INSERT INTO foo VALUES (1234)", true, "INSERT INTO `foo` VALUES (1234)"},
 		{"INSERT INTO foo VALUES (1234, 5678)", true, "INSERT INTO `foo` VALUES (1234,5678)"},
 		{"INSERT INTO t1 (SELECT * FROM t2)", true, "INSERT INTO `t1` SELECT * FROM `t2`"},
+		{"INSERT INTO t partition (p0) values(1234)", true, "INSERT INTO `t` partition(`p0`) VALUES (1234)"},
+		{"REPLACE INTO t partition (p0) values(1234)", true, "REPLACE INTO `t` partition(`p0`) VALUES (1234)"},
 		// 15
 		{"INSERT INTO foo VALUES (1 || 2)", true, "INSERT INTO `foo` VALUES (1 OR 2)"},
 		{"INSERT INTO foo VALUES (1 | 2)", true, "INSERT INTO `foo` VALUES (1|2)"},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Before this commit,
`insert into t partition(p0,...) values(xxx)` will cause a syntax error.

### What is changed and how it works?
Add the support for `insert/replace into t partition(p0,...)`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note

### Release Note
- Support the syntax `insert/replace into tbl_name partition(p_name0, ...)`
