### PR TITLE
parser: support using dash('-') in config item names 

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -1232,6 +1232,7 @@ import (
 	FunctionNameDateArith           "Date arith function call names (date_add or date_sub)"
 	FunctionNameDateArithMultiForms "Date arith function call names (adddate or subdate)"
 	VariableName                    "A simple Identifier like xx or the xx.xx form"
+	ConfigItemName                  "A config item like aa or aa.bb or aa.bb-cc.dd"
 	StringNameOrBRIEOptionKeyword   "string literal or identifier or keyword used for BRIE options"
 
 %precedence empty
@@ -8054,11 +8055,11 @@ SetStmt:
 		}
 		$$ = &ast.SetStmt{Variables: assigns}
 	}
-|	"SET" "CONFIG" Identifier VariableName EqOrAssignmentEq SetExpr
+|	"SET" "CONFIG" Identifier ConfigItemName EqOrAssignmentEq SetExpr
 	{
 		$$ = &ast.SetConfigStmt{Type: strings.ToLower($3), Name: $4, Value: $6}
 	}
-|	"SET" "CONFIG" stringLit VariableName EqOrAssignmentEq SetExpr
+|	"SET" "CONFIG" stringLit ConfigItemName EqOrAssignmentEq SetExpr
 	{
 		$$ = &ast.SetConfigStmt{Instance: $3, Name: $4, Value: $6}
 	}
@@ -8184,6 +8185,17 @@ VariableName:
 |	Identifier '.' Identifier
 	{
 		$$ = $1 + "." + $3
+	}
+
+ConfigItemName:
+	Identifier
+|	Identifier '.' ConfigItemName
+	{
+		$$ = $1 + "." + $3
+	}
+|	Identifier '-' ConfigItemName
+	{
+		$$ = $1 + "-" + $3
 	}
 
 VariableAssignment:

--- a/parser_test.go
+++ b/parser_test.go
@@ -1050,6 +1050,8 @@ func (s *testParserSuite) TestDBAStmt(c *C) {
 		{"set config PD LOG.LEVEL='info'", true, "SET CONFIG PD LOG.LEVEL = 'info'"},
 		{"set config TIDB LOG.LEVEL='info'", true, "SET CONFIG TIDB LOG.LEVEL = 'info'"},
 		{"set config '127.0.0.1:3306' LOG.LEVEL='info'", true, "SET CONFIG '127.0.0.1:3306' LOG.LEVEL = 'info'"},
+		{"set config '127.0.0.1:3306' AUTO-COMPACTION-MODE=TRUE", true, "SET CONFIG '127.0.0.1:3306' AUTO-COMPACTION-MODE = TRUE"},
+		{"set config '127.0.0.1:3306' LABEL-PROPERTY.REJECT-LEADER.KEY='zone'", true, "SET CONFIG '127.0.0.1:3306' LABEL-PROPERTY.REJECT-LEADER.KEY = 'zone'"},
 		{"show config", true, "SHOW CONFIG"},
 		{"show config where type='tidb'", true, "SHOW CONFIG WHERE `type`='tidb'"},
 		{"show config where instance='127.0.0.1:3306'", true, "SHOW CONFIG WHERE `instance`='127.0.0.1:3306'"},


### PR DESCRIPTION
Pick for https://github.com/pingcap/parser/pull/821.