### PR TITLE
model: correct the usage of json.Unmarshal in DecodeArgs

### DIFF
--- a/model/ddl.go
+++ b/model/ddl.go
@@ -287,15 +287,18 @@ func (job *Job) DecodeArgs(args ...interface{}) error {
 		return err
 	}
 
-	for i := 0; ; i++ {
-		if i == len(rawArgs) || i == len(args) {
-			job.Args = args[:i]
-			return nil
-		}
+	sz := len(rawArgs)
+	if sz > len(args) {
+		sz = len(args)
+	}
+
+	for i := 0; i < sz; i++ {
 		if err := json.Unmarshal(rawArgs[i], args[i]); err != nil {
 			return err
 		}
 	}
+	job.Args = args[:sz]
+	return nil
 }
 
 // String implements fmt.Stringer interface.

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -282,9 +282,20 @@ func (job *Job) Decode(b []byte) error {
 
 // DecodeArgs decodes job args.
 func (job *Job) DecodeArgs(args ...interface{}) error {
-	job.Args = args
-	err := json.Unmarshal(job.RawArgs, &job.Args)
-	return errors.Trace(err)
+	var rawArgs []json.RawMessage
+	if err := json.Unmarshal(job.RawArgs, &rawArgs); err != nil {
+		return err
+	}
+
+	for i := 0; ; i++ {
+		if i == len(rawArgs) || i == len(args) {
+			job.Args = args[:i]
+			return nil
+		}
+		if err := json.Unmarshal(rawArgs[i], args[i]); err != nil {
+			return err
+		}
+	}
 }
 
 // String implements fmt.Stringer interface.

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -284,7 +284,7 @@ func (job *Job) Decode(b []byte) error {
 func (job *Job) DecodeArgs(args ...interface{}) error {
 	var rawArgs []json.RawMessage
 	if err := json.Unmarshal(job.RawArgs, &rawArgs); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	sz := len(rawArgs)
@@ -294,7 +294,7 @@ func (job *Job) DecodeArgs(args ...interface{}) error {
 
 	for i := 0; i < sz; i++ {
 		if err := json.Unmarshal(rawArgs[i], args[i]); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 	job.Args = args[:sz]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fixed #889

### What is changed and how it works?
> decoding into []json.RawMessage, so you can then decode each into the appropriate type in a second pass

Using `json.Decoder` is more complex.

```go
if len(job.RawArgs) == 0 {
	return nil
}

decoder := json.NewDecoder(bytes.NewReader(job.RawArgs))
token, err := decoder.Token()
if err != nil {
	return errors.Trace(err)
}
if del, ok := token.(json.Delim); !ok || del != '[' {
	return nil
}

var i int
for decoder.More() {
	if i == len(args) {
		break
	}
	if err := decoder.Decode(args[i]); err != nil {
		return errors.Trace(err)
	}
	i++
}
job.Args = args[:i]
return nil
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
 - Run TiDB's unit-test with Go 1.15 

Side effects

 - Possible performance regression
