### PR TITLE
types: fix restore cast as binary

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1348,6 +1348,7 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"SELECT *, CAST(data AS CHAR CHARACTER SET utf8) FROM t;", true, "SELECT *,CAST(`data` AS CHAR CHARSET UTF8) FROM `t`"},
 		{"SELECT CAST(data AS CHARACTER);", true, "SELECT CAST(`data` AS CHAR)"},
 		{"SELECT CAST(data AS CHARACTER(10) CHARACTER SET utf8);", true, "SELECT CAST(`data` AS CHAR(10) CHARSET UTF8)"},
+		{"SELECT CAST(data AS BINARY)", true, "SELECT CAST(`data` AS BINARY)"},
 
 		// for cast as JSON
 		{"SELECT *, CAST(data AS JSON) FROM t;", true, "SELECT *,CAST(`data` AS JSON) FROM `t`"},

--- a/types/field_type.go
+++ b/types/field_type.go
@@ -260,15 +260,17 @@ func (ft *FieldType) Restore(ctx *format.RestoreCtx) error {
 func (ft *FieldType) RestoreAsCastType(ctx *format.RestoreCtx) {
 	switch ft.Tp {
 	case mysql.TypeVarString:
+		skipWriteBinary := false
 		if ft.Charset == charset.CharsetBin && ft.Collate == charset.CollationBin {
 			ctx.WriteKeyWord("BINARY")
+			skipWriteBinary = true
 		} else {
 			ctx.WriteKeyWord("CHAR")
 		}
 		if ft.Flen != UnspecifiedLength {
 			ctx.WritePlainf("(%d)", ft.Flen)
 		}
-		if ft.Flag&mysql.BinaryFlag != 0 {
+		if !skipWriteBinary && ft.Flag&mysql.BinaryFlag != 0 {
 			ctx.WriteKeyWord(" BINARY")
 		}
 		if ft.Charset != charset.CharsetBin && ft.Charset != mysql.DefaultCharset {


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tidb/issues/18148

Before this PR:
`SELECT CAST(data AS BINARY)` will be restored to ``SELECT CAST(`data` AS BINARY BINARY)``

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes



Side effects


Related changes

 - Need to cherry-pick to the release branch

