### PR TITLE
feat: add "HISTOGRAM" option in "ALTER TABLE... UPDATE/DROP..."

### DIFF
--- a/ast/stats.go
+++ b/ast/stats.go
@@ -37,6 +37,9 @@ type AnalyzeTableStmt struct {
 	// IndexFlag is true when we only analyze indices for a table.
 	IndexFlag   bool
 	Incremental bool
+	// HistogramOperation is set in "ANALYZE TABLE ... UPDATE/DROP HISTOGRAM ..." statement.
+	HistogramOperation HistogramOperationType
+	ColumnNames        []*ColumnName
 }
 
 // AnalyzeOptType is the type for analyze options.
@@ -58,6 +61,23 @@ var AnalyzeOptionString = map[AnalyzeOptionType]string{
 	AnalyzeOptCMSketchWidth: "CMSKETCH WIDTH",
 	AnalyzeOptCMSketchDepth: "CMSKETCH DEPTH",
 	AnalyzeOptNumSamples:    "SAMPLES",
+}
+
+// HistogramOperationType is the type for histogram operation.
+type HistogramOperationType int
+
+// Histogram operation types.
+const (
+	// HistogramOperationNop shows no operation in histogram. Default value.
+	HistogramOperationNop = iota
+	HistogramOperationUpdate
+	HistogramOperationDrop
+)
+
+// HistogramOperationString stores the string form of histogram operation.
+var HistogramOperationString = map[HistogramOperationType]string{
+	HistogramOperationUpdate: "UPDATE HISTOGRAM",
+	HistogramOperationDrop:   "DROP HISTOGRAM",
 }
 
 // AnalyzeOpt stores the analyze option type and value.
@@ -89,6 +109,18 @@ func (n *AnalyzeTableStmt) Restore(ctx *format.RestoreCtx) error {
 			ctx.WritePlain(",")
 		}
 		ctx.WriteName(partition.O)
+	}
+	if n.HistogramOperation != HistogramOperationNop {
+		ctx.WriteKeyWord(" " + HistogramOperationString[n.HistogramOperation] + " ")
+	}
+	if len(n.ColumnNames) > 0 {
+		ctx.WriteKeyWord("ON ")
+		for i, columnName := range n.ColumnNames {
+			if i != 0 {
+				ctx.WritePlain(",")
+			}
+			ctx.WriteName(columnName.Name.O)
+		}
 	}
 	if n.IndexFlag {
 		ctx.WriteKeyWord(" INDEX")

--- a/ast/stats.go
+++ b/ast/stats.go
@@ -69,15 +69,20 @@ type HistogramOperationType int
 // Histogram operation types.
 const (
 	// HistogramOperationNop shows no operation in histogram. Default value.
-	HistogramOperationNop = iota
+	HistogramOperationNop HistogramOperationType = iota
 	HistogramOperationUpdate
 	HistogramOperationDrop
 )
 
-// HistogramOperationString stores the string form of histogram operation.
-var HistogramOperationString = map[HistogramOperationType]string{
-	HistogramOperationUpdate: "UPDATE HISTOGRAM",
-	HistogramOperationDrop:   "DROP HISTOGRAM",
+// String implements fmt.Stringer for HistogramOperationType.
+func (hot HistogramOperationType) String() string {
+	switch hot {
+	case HistogramOperationUpdate:
+		return "UPDATE HISTOGRAM"
+	case HistogramOperationDrop:
+		return "DROP HISTOGRAM"
+	}
+	return ""
 }
 
 // AnalyzeOpt stores the analyze option type and value.
@@ -111,7 +116,9 @@ func (n *AnalyzeTableStmt) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteName(partition.O)
 	}
 	if n.HistogramOperation != HistogramOperationNop {
-		ctx.WriteKeyWord(" " + HistogramOperationString[n.HistogramOperation] + " ")
+		ctx.WritePlain(" ")
+		ctx.WriteKeyWord(n.HistogramOperation.String())
+		ctx.WritePlain(" ")
 	}
 	if len(n.ColumnNames) > 0 {
 		ctx.WriteKeyWord("ON ")

--- a/misc.go
+++ b/misc.go
@@ -352,6 +352,7 @@ var tokenMap = map[string]int{
 	"HAVING":                   having,
 	"HIGH_PRIORITY":            highPriority,
 	"HISTORY":                  history,
+	"HISTOGRAM":                histogram,
 	"HOSTS":                    hosts,
 	"HOUR_MICROSECOND":         hourMicrosecond,
 	"HOUR_MINUTE":              hourMinute,

--- a/parser.y
+++ b/parser.y
@@ -393,6 +393,7 @@ import (
 	global                "GLOBAL"
 	grants                "GRANTS"
 	hash                  "HASH"
+	histogram             "HISTOGRAM"
 	history               "HISTORY"
 	hosts                 "HOSTS"
 	hour                  "HOUR"
@@ -2365,6 +2366,23 @@ AnalyzeTableStmt:
 			IndexFlag:      true,
 			Incremental:    true,
 			AnalyzeOpts:    $9.([]ast.AnalyzeOpt),
+		}
+	}
+|	"ANALYZE" "TABLE" TableName "UPDATE" "HISTOGRAM" "ON" ColumnNameList AnalyzeOptionListOpt
+	{
+		$$ = &ast.AnalyzeTableStmt{
+			TableNames:         []*ast.TableName{$3.(*ast.TableName)},
+			ColumnNames:        $7.([]*ast.ColumnName),
+			AnalyzeOpts:        $8.([]ast.AnalyzeOpt),
+			HistogramOperation: ast.HistogramOperationUpdate,
+		}
+	}
+|	"ANALYZE" "TABLE" TableName "DROP" "HISTOGRAM" "ON" ColumnNameList
+	{
+		$$ = &ast.AnalyzeTableStmt{
+			TableNames:         []*ast.TableName{$3.(*ast.TableName)},
+			ColumnNames:        $7.([]*ast.ColumnName),
+			HistogramOperation: ast.HistogramOperationDrop,
 		}
 	}
 
@@ -5282,6 +5300,7 @@ UnReservedKeyword:
 |	"TRADITIONAL"
 |	"SQL_BUFFER_RESULT"
 |	"DIRECTORY"
+|	"HISTOGRAM"
 |	"HISTORY"
 |	"LIST"
 |	"NODEGROUP"

--- a/parser_test.go
+++ b/parser_test.go
@@ -4443,6 +4443,8 @@ func (s *testParserSuite) TestAnalyze(c *C) {
 		{"analyze table t partition a index b with 4 buckets", true, "ANALYZE TABLE `t` PARTITION `a` INDEX `b` WITH 4 BUCKETS"},
 		{"analyze incremental table t index", true, "ANALYZE INCREMENTAL TABLE `t` INDEX"},
 		{"analyze incremental table t index idx", true, "ANALYZE INCREMENTAL TABLE `t` INDEX `idx`"},
+		{"analyze table t update histogram on b with 1024 buckets", true, "ANALYZE TABLE `t` UPDATE HISTOGRAM ON `b` WITH 1024 BUCKETS"},
+		{"analyze table t drop histogram on b", true, "ANALYZE TABLE `t` DROP HISTOGRAM ON `b`"},
 	}
 	s.RunTest(c, table)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -4445,6 +4445,8 @@ func (s *testParserSuite) TestAnalyze(c *C) {
 		{"analyze incremental table t index idx", true, "ANALYZE INCREMENTAL TABLE `t` INDEX `idx`"},
 		{"analyze table t update histogram on b with 1024 buckets", true, "ANALYZE TABLE `t` UPDATE HISTOGRAM ON `b` WITH 1024 BUCKETS"},
 		{"analyze table t drop histogram on b", true, "ANALYZE TABLE `t` DROP HISTOGRAM ON `b`"},
+		{"analyze table t update histogram on c1, c2;", true, "ANALYZE TABLE `t` UPDATE HISTOGRAM ON `c1`,`c2`"},
+		{"analyze table t drop histogram on c1, c2;", true, "ANALYZE TABLE `t` DROP HISTOGRAM ON `c1`,`c2`"},
 	}
 	s.RunTest(c, table)
 }


### PR DESCRIPTION
Signed-off-by: Wang Ruichao <wangruichao2014@xiaochuankeji.cn>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Close #361 , cc https://github.com/pingcap/tidb/issues/14800

### Bad SQL:

```SQL
ANALYZE TABLE `t1` UPDATE HISTOGRAM ON `b` WITH 1024 BUCKETS;
```

### What is changed and how it works?

Add "ALTER TABLE... UPDATE/DROP HISTOGRAM" in parser.y, according to the document of mysql: https://dev.mysql.com/doc/refman/8.0/en/analyze-table.html

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
