### PR TITLE
parser.y: Always populate SelectField offset

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -4755,23 +4755,36 @@ LikeEscapeOpt:
 Field:
 	'*'
 	{
-		$$ = &ast.SelectField{WildCard: &ast.WildCardField{}}
+		$$ = &ast.SelectField{
+			WildCard: &ast.WildCardField{},
+			Offset:   parser.startOffset(&yyS[yypt]),
+		}
 	}
 |	Identifier '.' '*'
 	{
 		wildCard := &ast.WildCardField{Table: model.NewCIStr($1)}
-		$$ = &ast.SelectField{WildCard: wildCard}
+		$$ = &ast.SelectField{
+			WildCard: wildCard,
+			Offset:   parser.startOffset(&yyS[yypt]),
+		}
 	}
 |	Identifier '.' Identifier '.' '*'
 	{
 		wildCard := &ast.WildCardField{Schema: model.NewCIStr($1), Table: model.NewCIStr($3)}
-		$$ = &ast.SelectField{WildCard: wildCard}
+		$$ = &ast.SelectField{
+			WildCard: wildCard,
+			Offset:   parser.startOffset(&yyS[yypt]),
+		}
 	}
 |	Expression FieldAsNameOpt
 	{
 		expr := $1
 		asName := $2
-		$$ = &ast.SelectField{Expr: expr, AsName: model.NewCIStr(asName)}
+		$$ = &ast.SelectField{
+			Expr:   expr,
+			AsName: model.NewCIStr(asName),
+			Offset: parser.startOffset(&yyS[yypt]),
+		}
 	}
 |	'{' Identifier Expression '}' FieldAsNameOpt
 	{
@@ -4781,7 +4794,11 @@ Field:
 		 */
 		expr := $3
 		asName := $5
-		$$ = &ast.SelectField{Expr: expr, AsName: model.NewCIStr(asName)}
+		$$ = &ast.SelectField{
+			Expr:   expr,
+			AsName: model.NewCIStr(asName),
+			Offset: parser.startOffset(&yyS[yypt]),
+		}
 	}
 
 FieldAsNameOpt:


### PR DESCRIPTION
👋 This is my time contributing code to this project, so please let me know if I need to do more work to get this approved. I'm happy to add tests, documentation, etc.

# What problem does this PR solve?
This is a partial solution to #910 

### What is changed and how it works?
`ast.SelectField` already has an Offset field. I've updated parser.y to populate this field whenever an `ast.SelectField` is created.
