### PR TITLE
quickstart.md: get dependency with git hash instead of version tag

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,10 +17,10 @@ go mod init colx && touch main.go
 
 ## Import Dependencies
 
-First of all, you need to use `go get` to fetch the dependencies:
+First of all, you need to use `go get` to fetch the dependencies(for v4.0.2, the git hash is `3a18f1e`):
 
 ```bash
-go get -v github.com/pingcap/parser@v4.0.0-rc.1
+go get -v github.com/pingcap/parser@3a18f1e
 ```
 
 > **NOTE**
@@ -28,7 +28,7 @@ go get -v github.com/pingcap/parser@v4.0.0-rc.1
 > You may want to use advanced API on expressions (a kind of AST node), such as numbers, string literals, booleans, nulls, etc. It is strongly recommended to use the `types` package in TiDB repo with the following command:
 >
 > ```bash
-> go get -v github.com/pingcap/tidb/types/parser_driver@v4.0.0-rc.1
+> go get -v github.com/pingcap/tidb/types/parser_driver@328b6d0
 > ```
 > and import it in your golang source code:
 > ```go

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,7 +17,7 @@ go mod init colx && touch main.go
 
 ## Import Dependencies
 
-First of all, you need to use `go get` to fetch the dependencies(for v4.0.2, the git hash is `3a18f1e`):
+First of all, you need to use `go get` to fetch the dependencies through git hash. The git hashes are available in [release page](https://github.com/pingcap/parser/releases). Take `release-4.0.2` as an example:
 
 ```bash
 go get -v github.com/pingcap/parser@3a18f1e

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,7 +17,7 @@ go mod init colx && touch main.go
 
 ## Import Dependencies
 
-First of all, you need to use `go get` to fetch the dependencies through git hash. The git hashes are available in [release page](https://github.com/pingcap/parser/releases). Take `release-4.0.2` as an example:
+First of all, you need to use `go get` to fetch the dependencies through git hash. The git hashes are available in [release page](https://github.com/pingcap/parser/releases). Take `v4.0.2` as an example:
 
 ```bash
 go get -v github.com/pingcap/parser@3a18f1e


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Using a version tag to `go get` the dependency is not the correct way. 

```console
go get github.com/pingcap/parser@v4.0.0-rc.1: github.com/pingcap/parser@v4.0.0-rc.1: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v4
```

Under ideal circumstances, the path should be something like 

```
github.com/pingcap/parser/v4@master
``` 

when the new major version is not backward compatible. However, this is still under discussion due to potential compatibility problems.

As a workaround, we can specify the git hash manually.


### What is changed and how it works?
See the changes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

N/A

Code changes

N/A

Side effects

N/A

Related changes

N/A
