### PR TITLE
parser: add config variable to control max display length

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -9791,7 +9791,7 @@ NumericType:
 		// TODO: check flen 0
 		x := types.NewFieldType($1.(byte))
 		x.Flen = $2.(int)
-		if $2.(int) != types.UnspecifiedLength {
+		if $2.(int) != types.UnspecifiedLength && types.TiDBStrictIntegerDisplayWidth {
 			yylex.AppendError(yylex.Errorf("Integer display width is deprecated and will be removed in a future release."))
 			parser.lastErrorAsWarn()
 		}


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Since TiDB and Parser has implemented much tests with int(11), bigint(20) and so on, it better to add the varible as a transition from `supported` to `deprecated`.
The benefit is that we don't have to change all the tests implemented with int(11) ,bigint(20) and so on, even some tests in the other repo, like TiDB-Test, Parser...

Also
TiDB [#18787](https://github.com/pingcap/tidb/pull/18787) is the pr to fix the integration test (removing the mysql.decimal field), but it's parser is including max-display-length-warning commit which I filed serveral days ago, which will cause test check failed in TiDB Repo.

So this pr is to correct the TiDB test check behavior.

### What is changed and how it works?
Add the config variable in parser drived by TiDB config.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
