### PR TITLE
parser: append replica-only state to previous one strictly

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -45,8 +45,7 @@ const (
 	// StateReplica means we're waiting tiflash replica to be finished.
 	StateReplicaOnly
 	/*
-	 * New states must be appended after the last one, since the value is assigned according
-	 * to the strict position. Otherwise it will cause rolling update failure.
+	 *  keep the values consistent across versions.
 	 */
 )
 

--- a/model/model.go
+++ b/model/model.go
@@ -45,7 +45,7 @@ const (
 	// StateReplica means we're waiting tiflash replica to be finished.
 	StateReplicaOnly
 	/*
-	 * Follower adding state must be appended to the last one, since the value is assigned according
+	 * New states must be appended after the last one, since the value is assigned according
 	 * to the strict position. Otherwise it will cause rolling update failure.
 	 */
 )

--- a/model/model.go
+++ b/model/model.go
@@ -36,14 +36,18 @@ const (
 	// StateWriteOnly means we can use any write operation on this schema element,
 	// but outer can't read the changed data.
 	StateWriteOnly
-	// StateReplica means we're waiting tiflash replica to be finished.
-	StateReplicaOnly
 	// StateWriteReorganization means we are re-organizing whole data after write only state.
 	StateWriteReorganization
 	// StateDeleteReorganization means we are re-organizing whole data after delete only state.
 	StateDeleteReorganization
 	// StatePublic means this schema element is ok for all write and read operations.
 	StatePublic
+	// StateReplica means we're waiting tiflash replica to be finished.
+	StateReplicaOnly
+	/*
+	 * Follower adding state must be appended to the last one, since the value is assigned according
+	 * to the strict position. Otherwise it will cause rolling update failure.
+	 */
 )
 
 // String implements fmt.Stringer interface.

--- a/model/model.go
+++ b/model/model.go
@@ -45,7 +45,7 @@ const (
 	// StateReplica means we're waiting tiflash replica to be finished.
 	StateReplicaOnly
 	/*
-	 *  keep the values consistent across versions.
+	 *  Please add the new state at the end to keep the values consistent across versions.
 	 */
 )
 


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The new added replica-only state should strictly be appended to the last one.
Otherwise, it will cause a rolling-update failure.
Referring issue: https://github.com/pingcap/tidb/issues/18873

### What is changed and how it works?
append replica-only state to previous one strictly

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

```
Manual test like what the issue described:
1: starting a TiDB (v4.0.0) server.
2: rolling update it to the TiDB master (commit 4170007fb60f3ad1ebb11027bbb6ac97c408929d).
3: checking this process without any error mentioned in the issue above.
```

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
