### PR TITLE
correct calculation of field lengths for Enum and Set types

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -10134,6 +10134,11 @@ StringType:
 	{
 		x := types.NewFieldType(mysql.TypeSet)
 		x.Elems = $3.([]string)
+		fieldLen := len(x.Elems) - 1
+		for _, e := range x.Elems {
+			fieldLen += len(e)
+		}
+		x.Flen = fieldLen
 		x.Charset = $5
 		$$ = x
 	}

--- a/parser.y
+++ b/parser.y
@@ -10120,7 +10120,7 @@ StringType:
 	{
 		x := types.NewFieldType(mysql.TypeEnum)
 		x.Elems = $3.([]string)
-		fieldLen := -1
+		fieldLen := -1 // enum_flen = max(ele_flen)
 		for _, e := range x.Elems {
 			if len(e) > fieldLen {
 				fieldLen = len(e)
@@ -10134,7 +10134,7 @@ StringType:
 	{
 		x := types.NewFieldType(mysql.TypeSet)
 		x.Elems = $3.([]string)
-		fieldLen := len(x.Elems) - 1
+		fieldLen := len(x.Elems) - 1 // set_flen = sum(ele_flen) + number_of_ele - 1
 		for _, e := range x.Elems {
 			fieldLen += len(e)
 		}

--- a/parser.y
+++ b/parser.y
@@ -10120,6 +10120,13 @@ StringType:
 	{
 		x := types.NewFieldType(mysql.TypeEnum)
 		x.Elems = $3.([]string)
+		fieldLen := -1
+		for _, e := range x.Elems {
+			if len(e) > fieldLen {
+				fieldLen = len(e)
+			}
+		}
+		x.Flen = fieldLen
 		x.Charset = $5
 		$$ = x
 	}

--- a/types/field_type_test.go
+++ b/types/field_type_test.go
@@ -243,8 +243,6 @@ func (s *testFieldTypeSuite) TestHasCharsetFromStmt(c *C) {
 
 func (s *testFieldTypeSuite) TestEnumSetFlen(c *C) {
 	p := parser.New()
-	// enum_flen = max(ele_flen)
-	// set_flen = sum(ele_flen) + number_of_ele - 1
 	cases := []struct {
 		sql string
 		ex  int

--- a/types/field_type_test.go
+++ b/types/field_type_test.go
@@ -241,6 +241,14 @@ func (s *testFieldTypeSuite) TestHasCharsetFromStmt(c *C) {
 	}
 }
 
+func (s *testFieldTypeSuite) TestEnumFlen(c *C) {
+	p := parser.New()
+	stmt, err := p.ParseOneStmt("create table t (e enum('a', 'bb', 'ccc'))", "", "")
+	c.Assert(err, IsNil)
+	col := stmt.(*ast.CreateTableStmt).Cols[0]
+	c.Assert(col.Tp.Flen, Equals, 3)
+}
+
 func (s *testFieldTypeSuite) TestFieldTypeEqual(c *C) {
 
 	// Tp not equal


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Related to https://github.com/pingcap/tidb/issues/18870.

Correct calculation of field lengths for Enum and Set types

### What is changed and how it works?
Now, when creating tables, field lengths for Enum and Set type columns are set to -1, which is not correct.

This PR fixes their field length as rules below:
1. enum_flen = max(element_flen)
2. set_flen = sum(element_flen) + number_of_elements - 1

These rules are from MySQL.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
