### PR TITLE
correct calculation of field lengths for Enum and Set types

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -10033,6 +10033,13 @@ StringType:
 	{
 		x := types.NewFieldType(mysql.TypeEnum)
 		x.Elems = $3.([]string)
+		fieldLen := -1 // enum_flen = max(ele_flen)
+		for _, e := range x.Elems {
+			if len(e) > fieldLen {
+				fieldLen = len(e)
+			}
+		}
+		x.Flen = fieldLen
 		x.Charset = $5.(string)
 		$$ = x
 	}
@@ -10040,6 +10047,11 @@ StringType:
 	{
 		x := types.NewFieldType(mysql.TypeSet)
 		x.Elems = $3.([]string)
+		fieldLen := len(x.Elems) - 1 // set_flen = sum(ele_flen) + number_of_ele - 1
+		for _, e := range x.Elems {
+			fieldLen += len(e)
+		}
+		x.Flen = fieldLen
 		x.Charset = $5.(string)
 		$$ = x
 	}

--- a/types/field_type_test.go
+++ b/types/field_type_test.go
@@ -193,6 +193,38 @@ func (s *testFieldTypeSuite) TestFieldType(c *C) {
 	c.Assert(HasCharset(ft), IsFalse)
 }
 
+func (s *testFieldTypeSuite) TestEnumSetFlen(c *C) {
+	p := parser.New()
+	cases := []struct {
+		sql string
+		ex  int
+	}{
+		{"enum('a')", 1},
+		{"enum('a', 'b')", 1},
+		{"enum('a', 'bb')", 2},
+		{"enum('a', 'b', 'c')", 1},
+		{"enum('a', 'bb', 'c')", 2},
+		{"enum('a', 'bb', 'c')", 2},
+		{"enum('')", 0},
+		{"enum('a', '')", 1},
+		{"set('a')", 1},
+		{"set('a', 'b')", 3},
+		{"set('a', 'bb')", 4},
+		{"set('a', 'b', 'c')", 5},
+		{"set('a', 'bb', 'c')", 6},
+		{"set('')", 0},
+		{"set('a', '')", 2},
+	}
+
+	for _, ca := range cases {
+		stmt, err := p.ParseOneStmt(fmt.Sprintf("create table t (e %v)", ca.sql), "", "")
+		c.Assert(err, IsNil)
+		col := stmt.(*ast.CreateTableStmt).Cols[0]
+		c.Assert(col.Tp.Flen, Equals, ca.ex)
+
+	}
+}
+
 func (s *testFieldTypeSuite) TestHasCharsetFromStmt(c *C) {
 	template := "CREATE TABLE t(a %s)"
 


### PR DESCRIPTION
Cherry pick for https://github.com/pingcap/parser/pull/954.

---

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Related to https://github.com/pingcap/tidb/issues/18870.

Correct calculation of field lengths for Enum and Set types

### What is changed and how it works?
Now, when creating tables, field lengths for Enum and Set type columns are set to -1, which is not correct.

This PR fixes their field length as rules below:
1. enum_flen = max(element_flen)
2. set_flen = sum(element_flen) + number_of_elements - 1

These rules are from MySQL.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
