### PR TITLE
Populate offset for func calls

### DIFF
--- a/ast/functions.go
+++ b/ast/functions.go
@@ -356,6 +356,8 @@ type FuncCallExpr struct {
 	FnName model.CIStr
 	// Args is the function args.
 	Args []ExprNode
+	// Offset is used to get original text.
+	Offset int
 }
 
 // Restore implements Node interface.

--- a/parser.y
+++ b/parser.y
@@ -6631,6 +6631,7 @@ FunctionCallGeneric:
 	}
 |	Identifier '.' Identifier '(' ExpressionListOpt ')'
 	{
+		offset := parser.startOffset(&yyS[yypt-5])
 		var tp ast.FuncCallExprType
 		if isInTokenMap($3) {
 			tp = ast.FuncCallExprTypeKeyword
@@ -6638,6 +6639,7 @@ FunctionCallGeneric:
 			tp = ast.FuncCallExprTypeGeneric
 		}
 		$$ = &ast.FuncCallExpr{
+			Offset: offset,
 			Tp:     tp,
 			Schema: model.NewCIStr($1),
 			FnName: model.NewCIStr($3),

--- a/parser_test.go
+++ b/parser_test.go
@@ -4290,6 +4290,32 @@ func (s *testParserSuite) TestTimestampDiffUnit(c *C) {
 	s.RunTest(c, table)
 }
 
+func (s *testParserSuite) TestFuncCallExprOffset(c *C) {
+	// Test case for offset field on func call expr.
+	parser := parser.New()
+	stmt, _, err := parser.Parse("SELECT s.a(), b();", "", "")
+	c.Assert(err, IsNil)
+	ss := stmt[0].(*ast.SelectStmt)
+	fields := ss.Fields.Fields
+	c.Assert(len(fields), Equals, 2)
+
+	{
+		// s.a()
+		expr := fields[0].Expr
+		f, ok := expr.(*ast.FuncCallExpr)
+		c.Assert(ok, IsTrue)
+		c.Assert(f.Offset, Equals, 7)
+	}
+
+	{
+		// b()
+		expr := fields[1].Expr
+		f, ok := expr.(*ast.FuncCallExpr)
+		c.Assert(ok, IsTrue)
+		c.Assert(f.Offset, Equals, 0)
+	}
+}
+
 func (s *testParserSuite) TestSessionManage(c *C) {
 	table := []testCase{
 		// Kill statement.


### PR DESCRIPTION
### What problem does this PR solve?

I use this package to power the MySQL support in https://github.com/kyleconry/sqlc. One of the features in sqlc is named parameter support via functions. For example, sqlc will take this query

```sql
/* name: BooksByTitleYear :many */
SELECT * FROM books
WHERE title = sqlc.arg('title');
```

And rewrite it with parameter placeholders

```sql
/* name: BooksByTitleYear :many */
SELECT * FROM books
WHERE title = ?;
```

### What is changed and how it works?

To support this functionality, I've added an Offset field to `FuncCallExpr`. It behaves exactly like the Offset field on SelectField. I've only updated the call site that I need, but happy to do it every place a FuncCallExpr is initialized.

### Check List

Tests

 - Integration test (this lives in the sqlc repository)

Code changes

 - Has exported variable/fields change

