### PR TITLE
model: add StateReplicaOnly type to string

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -62,6 +62,8 @@ func (s SchemaState) String() string {
 		return "delete reorganization"
 	case StatePublic:
 		return "public"
+	case StateReplicaOnly:
+		return "replica only"
 	default:
 		return "none"
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In `StateReplicaOnly` schema state, we see the log is `SchemaState:none`.

### What is changed and how it works?
Add replica only type to `String`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
