### PR TITLE
model: fix null origin default value for bit column

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -151,7 +151,7 @@ func (c *ColumnInfo) SetOriginDefaultValue(value interface{}) error {
 
 // GetOriginalDefaultValue gets the origin default value.
 func (c *ColumnInfo) GetOriginDefaultValue() interface{} {
-	if c.Tp == mysql.TypeBit {
+	if c.Tp == mysql.TypeBit && c.OriginDefaultValueBit != nil {
 		// If the column type is BIT, both `OriginDefaultValue` and `DefaultValue` of ColumnInfo are corrupted,
 		// because the content before json.Marshal is INCONSISTENT with the content after json.Unmarshal.
 		return string(c.OriginDefaultValueBit)

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -363,6 +363,13 @@ func (testModelSuite) TestDefaultValue(c *C) {
 	err = newBitCol.SetDefaultValue(randBitStr)
 	c.Assert(newBitCol.GetDefaultValue(), Equals, randBitStr)
 
+	nullBitCol := srcCol.Clone()
+	nullBitCol.Name = NewCIStr("nullBitCol")
+	nullBitCol.FieldType = *types.NewFieldType(mysql.TypeBit)
+	err = nullBitCol.SetOriginDefaultValue(nil)
+	c.Assert(err, IsNil)
+	c.Assert(nullBitCol.GetOriginDefaultValue(), IsNil)
+
 	testCases := []struct {
 		col          *ColumnInfo
 		isConsistent bool
@@ -371,6 +378,7 @@ func (testModelSuite) TestDefaultValue(c *C) {
 		{oldBitCol, false},
 		{newPlainCol, true},
 		{newBitCol, true},
+		{nullBitCol, true},
 	}
 	for _, tc := range testCases {
 		col, isConsistent := tc.col, tc.isConsistent


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In PR pingcap/tidb#18036,
```sql
drop table if exists t;
create table t (a bit);
insert into t values (null);
select count(*) from t where a is null;
```

Expected: 
```
+----------+
| count(*) |
+----------+
| 1        |
+----------+
```
But got:
```
+----------+
| count(*) |
+----------+
| 0        |
+----------+
```
If the origin default value in the BIT column is null, it should not be converted to a string. 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

N/A

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

