### PR TITLE
parser: add `FETCH FIRST` syntax support

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -567,6 +567,7 @@ var tokenMap = map[string]int{
 	"ROW_COUNT":                rowCount,
 	"ROW_FORMAT":               rowFormat,
 	"ROW":                      row,
+	"ROWS":                     rows,
 	"RTREE":                    rtree,
 	"SAMPLES":                  samples,
 	"SAN":                      san,
@@ -794,7 +795,6 @@ var windowFuncTokenMap = map[string]int{
 	"OVER":         over,
 	"PERCENT_RANK": percentRank,
 	"RANK":         rank,
-	"ROWS":         rows,
 	"ROW_NUMBER":   rowNumber,
 	"WINDOW":       window,
 }

--- a/misc.go
+++ b/misc.go
@@ -322,6 +322,7 @@ var tokenMap = map[string]int{
 	"EXTRACT":                  extract,
 	"FALSE":                    falseKwd,
 	"FAULTS":                   faultsSym,
+	"FETCH":                    fetch,
 	"FIELDS":                   fields,
 	"FILE":                     file,
 	"FIRST":                    first,

--- a/parser.y
+++ b/parser.y
@@ -127,6 +127,7 @@ import (
 	explain           "EXPLAIN"
 	except            "EXCEPT"
 	falseKwd          "FALSE"
+	fetch             "FETCH"
 	firstValue        "FIRST_VALUE"
 	floatType         "FLOAT"
 	forKwd            "FOR"
@@ -909,6 +910,7 @@ import (
 	ExpressionList                         "expression list"
 	MaxValueOrExpressionList               "maxvalue or expression list"
 	ExpressionListOpt                      "expression list opt"
+	FetchFirstOpt                          "Fetch First/Next Option"
 	FuncDatetimePrecListOpt                "Function datetime precision list opt"
 	FuncDatetimePrecList                   "Function datetime precision list"
 	Field                                  "field expression"
@@ -1227,6 +1229,8 @@ import (
 	FieldsOrColumns   "Fields or columns"
 	StorageMedia      "{DISK|MEMORY|DEFAULT}"
 	EncryptionOpt     "Encryption option 'Y' or 'N'"
+	FirstOrNext       "FIRST or NEXT"
+	RowOrRows         "ROW or ROWS"
 
 %type	<ident>
 	ODBCDateTimeType                "ODBC type keywords for date and time literals"
@@ -7809,6 +7813,20 @@ LimitOption:
 		$$ = ast.NewParamMarkerExpr(yyS[yypt].offset)
 	}
 
+RowOrRows:
+	"ROW"
+|	"ROWS"
+
+FirstOrNext:
+	"FIRST"
+|	"NEXT"
+
+FetchFirstOpt:
+	{
+		$$ = ast.NewValueExpr(1, parser.charset, parser.collation)
+	}
+|	LimitOption
+
 SelectStmtLimit:
 	{
 		$$ = nil
@@ -7824,6 +7842,10 @@ SelectStmtLimit:
 |	"LIMIT" LimitOption "OFFSET" LimitOption
 	{
 		$$ = &ast.Limit{Offset: $4.(ast.ExprNode), Count: $2.(ast.ExprNode)}
+	}
+|	"FETCH" FirstOrNext FetchFirstOpt RowOrRows "ONLY"
+	{
+		$$ = &ast.Limit{Count: $3.(ast.ExprNode)}
 	}
 
 SelectStmtOpts:

--- a/parser.y
+++ b/parser.y
@@ -7823,7 +7823,7 @@ FirstOrNext:
 
 FetchFirstOpt:
 	{
-		$$ = ast.NewValueExpr(1, parser.charset, parser.collation)
+		$$ = ast.NewValueExpr(uint64(1), parser.charset, parser.collation)
 	}
 |	LimitOption
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -53,7 +53,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"current_timestamp", "current_user", "database", "databases", "day_hour", "day_microsecond",
 		"day_minute", "day_second", "decimal", "default", "delete", "desc", "describe",
 		"distinct", "distinctRow", "div", "double", "drop", "dual", "else", "enclosed", "escaped",
-		"exists", "explain", "false", "float", "for", "force", "foreign", "from",
+		"exists", "explain", "false", "float", "fetch", "for", "force", "foreign", "from",
 		"fulltext", "grant", "group", "having", "hour_microsecond", "hour_minute",
 		"hour_second", "if", "ignore", "in", "index", "infile", "inner", "insert", "int", "into", "integer",
 		"interval", "is", "join", "key", "keys", "kill", "leading", "left", "like", "limit", "lines", "load",
@@ -736,6 +736,14 @@ func (s *testParserSuite) TestDMLStmt(c *C) {
 
 		// for select with where clause
 		{"SELECT * FROM t WHERE 1 = 1", true, "SELECT * FROM `t` WHERE 1=1"},
+
+		// for select with FETCH FIRST syntax
+		{"SELECT * FROM t FETCH FIRST 5 ROW ONLY", true, "SELECT * FROM `t` LIMIT 5"},
+		{"SELECT * FROM t FETCH NEXT 5 ROW ONLY", true, "SELECT * FROM `t` LIMIT 5"},
+		{"SELECT * FROM t FETCH FIRST 5 ROWS ONLY", true, "SELECT * FROM `t` LIMIT 5"},
+		{"SELECT * FROM t FETCH NEXT 5 ROWS ONLY", true, "SELECT * FROM `t` LIMIT 5"},
+		{"SELECT * FROM t FETCH FIRST ROW ONLY", true, "SELECT * FROM `t` LIMIT 1"},
+		{"SELECT * FROM t FETCH NEXT ROW ONLY", true, "SELECT * FROM `t` LIMIT 1"},
 
 		// for dual
 		{"select 1 from dual", true, "SELECT 1"},


### PR DESCRIPTION
### What problem does this PR solve? 

#973
not close it because only a part of the syntax is supported.

### What is changed and how it works?

Support `FETCH { FIRST | NEXT } [ n ] { ROW | ROWS } ONLY` syntax.

Note1: 

MS SQL Server/Oracle/PostgreSQL support `[ OFFSET m { ROW | ROWS } ] FETCH { FIRST | NEXT } [ n ] { ROW | ROWS } ONLY` syntax. We didn't implement the `[ OFFSET m { ROW | ROWS } ]` part.

That's because `offset` is not a reserved word in MySQL(which is we need to be compatible with) so SQLs like `select * from t offset` and `select 1 offset` are valid. Supporting this syntax means we need to handle those SQLs and SQLs like `select a from t offset offset 3 rows fetch first 2 rows only` correctly. 

I'm not sure why yacc can't resolve this automatically but simply adding a rule for `[ OFFSET m { ROW | ROWS } ]` would cause syntax conflicts. Supporting that and supporting `offset` as an unreserved word can't be easily achieved at the same time based on our current syntax rules.

FYI, other Databases' behavior provided below.
MySQL: `offset` is not a reserved word. The "FETCH FIRST" syntax is not supported.
MS SQL Server: `offset` is not a reserved word. The syntax is supported but must be used after the `ORDER BY` clause.
DB2 & Oracle: `offset` is not a reserved word. The syntax is supported.
PostgreSQL: `offset` is a reserved word. The syntax is supported.

Note2: 

Currently, window function related tokens are treated differently. When window function enabled, these tokens are treated as reserved words. When disabled, they are treated as not keywords.
There is a test for this: https://github.com/pingcap/parser/blob/cc152d5441ed1e684593afb0e25d8389fb69f29d/parser_test.go#L4748-L4761
`ROWS` are one of these window function tokens, but to support this new syntax, we need to treat `ROWS` as a reserved word.
So I modified the `tokenMap` to always treat `ROWS` as a reserved word. This behavior is consistent with MySQL 8.0 but not consistent with MySQL 5.x since `ROWS` became reserved in MySQL 8.0.2.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects
 - Breaking backward compatibility (`ROWS` becomes reserved)

Related changes
 - Need to update the documentation
 - Need to be included in the release note
