### PR TITLE
terror: add stack trace in terror log

### DIFF
--- a/terror/terror.go
+++ b/terror/terror.go
@@ -357,7 +357,7 @@ func MustNil(err error, closeFuns ...func()) {
 		for _, f := range closeFuns {
 			f()
 		}
-		log.Fatal("unexpected error", zap.Error(err))
+		log.Fatal("unexpected error", zap.String("error", errors.ErrorStack(errors.Trace(err))))
 	}
 }
 
@@ -365,14 +365,14 @@ func MustNil(err error, closeFuns ...func()) {
 func Call(fn func() error) {
 	err := fn()
 	if err != nil {
-		log.Error("function call errored", zap.Error(err))
+		log.Error("function call errored", zap.String("error", errors.ErrorStack(errors.Trace(err))))
 	}
 }
 
 // Log logs the error if it is not nil.
 func Log(err error) {
 	if err != nil {
-		log.Error("encountered error", zap.Error(errors.WithStack(err)))
+		log.Error("encountered error", zap.String("error", errors.ErrorStack(errors.Trace(err))))
 	}
 }
 

--- a/terror/terror.go
+++ b/terror/terror.go
@@ -357,7 +357,7 @@ func MustNil(err error, closeFuns ...func()) {
 		for _, f := range closeFuns {
 			f()
 		}
-		log.Fatal("unexpected error", zap.String("error", errors.ErrorStack(errors.Trace(err))))
+		log.Fatal("unexpected error", zap.Error(err), zap.Stack("stack"))
 	}
 }
 
@@ -365,14 +365,14 @@ func MustNil(err error, closeFuns ...func()) {
 func Call(fn func() error) {
 	err := fn()
 	if err != nil {
-		log.Error("function call errored", zap.String("error", errors.ErrorStack(errors.Trace(err))))
+		log.Error("function call errored", zap.Error(err), zap.Stack("stack"))
 	}
 }
 
 // Log logs the error if it is not nil.
 func Log(err error) {
 	if err != nil {
-		log.Error("encountered error", zap.String("error", errors.ErrorStack(errors.Trace(err))))
+		log.Error("encountered error", zap.Error(err), zap.Stack("stack"))
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- None

### What is changed and how it works?

`terror.Log` can print stack trace for better debugging terror logs like https://asktug.com/t/topic/36843
```
$ go test -check.f TestLog
[2020/08/28 16:23:23.840 +08:00] [ERROR] [terror.go:375] ["encountered error"] [error="xxx\ngithub.com/pingcap/errors.AddStack\n\t/Users/sunrunaway/go/pkg/mod/github.com/pingcap/errors@v0.11.4/errors.go:174\ngithub.com/pingcap/errors.Trace\n\t/Users/sunrunaway/go/pkg/mod/github.com/pingcap/errors@v0.11.4/juju_adaptor.go:15\ngithub.com/pingcap/parser/terror.Log\n\t/Users/sunrunaway/code/gopath/src/github.com/pingcap/parser/terror/terror.go:375\ngithub.com/pingcap/parser/terror.(*testTErrorSuite).TestLog\n\t/Users/sunrunaway/code/gopath/src/github.com/pingcap/parser/terror/terror_test.go:167\nreflect.Value.call\n\t/usr/local/Cellar/go@1.13/1.13.9/libexec/src/reflect/value.go:460\nreflect.Value.Call\n\t/usr/local/Cellar/go@1.13/1.13.9/libexec/src/reflect/value.go:321\ngithub.com/pingcap/check.(*suiteRunner).forkTest.func1\n\t/Users/sunrunaway/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836\ngithub.com/pingcap/check.(*suiteRunner).forkCall.func1\n\t/Users/sunrunaway/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730\nruntime.goexit\n\t/usr/local/Cellar/go@1.13/1.13.9/libexec/src/runtime/asm_amd64.s:1357"] [stack="github.com/pingcap/log.Error\n\t/Users/sunrunaway/go/pkg/mod/github.com/pingcap/log@v0.0.0-20191012051959-b742a5d432e9/global.go:42\ngithub.com/pingcap/parser/terror.Log\n\t/Users/sunrunaway/code/gopath/src/github.com/pingcap/parser/terror/terror.go:375\ngithub.com/pingcap/parser/terror.(*testTErrorSuite).TestLog\n\t/Users/sunrunaway/code/gopath/src/github.com/pingcap/parser/terror/terror_test.go:167\nreflect.Value.call\n\t/usr/local/Cellar/go@1.13/1.13.9/libexec/src/reflect/value.go:460\nreflect.Value.Call\n\t/usr/local/Cellar/go@1.13/1.13.9/libexec/src/reflect/value.go:321\ngithub.com/pingcap/check.(*suiteRunner).forkTest.func1\n\t/Users/sunrunaway/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836\ngithub.com/pingcap/check.(*suiteRunner).forkCall.func1\n\t/Users/sunrunaway/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730"]
PASS: terror_test.go:165: testTErrorSuite.TestLog	0.000s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 
 - Manual test (add detailed scripts or steps below)
 
Related changes

 - Need to cherry-pick to the release branch

