### PR TITLE
expression: disable constrant flod for control expressions

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -335,20 +335,8 @@ func (n *CaseExpr) Accept(v Visitor) (Node, bool) {
 		}
 		n.Value = node.(ExprNode)
 	}
-	for i, val := range n.WhenClauses {
-		node, ok := val.Accept(v)
-		if !ok {
-			return n, false
-		}
-		n.WhenClauses[i] = node.(*WhenClause)
-	}
-	if n.ElseClause != nil {
-		node, ok := n.ElseClause.Accept(v)
-		if !ok {
-			return n, false
-		}
-		n.ElseClause = node.(ExprNode)
-	}
+	// the case ...when... args would not be executed, so they cannot be directly folded
+	// here directly leave the expr
 	return v.Leave(n)
 }
 

--- a/ast/functions.go
+++ b/ast/functions.go
@@ -518,7 +518,7 @@ func (n *FuncCallExpr) Accept(v Visitor) (Node, bool) {
 		// the remaining args would not be executed, so they cannot be directly folded
 		// here directly leave the expr
 		if i == 0 && (n.FnName.String() == "ifnull" || n.FnName.String() == "if") {
-			return v.Leave(newNode)
+			return v.Leave(n)
 		}
 	}
 	return v.Leave(n)

--- a/ast/functions.go
+++ b/ast/functions.go
@@ -504,7 +504,9 @@ func (n *FuncCallExpr) specialFormatArgs(w io.Writer) bool {
 // Accept implements Node interface.
 func (n *FuncCallExpr) Accept(v Visitor) (Node, bool) {
 	newNode, skipChildren := v.Enter(n)
-	if skipChildren {
+	// in ifnull() and if() expressions, some args would not be executed, so they cannot be directly folded
+	// here directly leave the expr
+	if skipChildren || n.FnName.String() == "ifnull" || n.FnName.String() == "if"{
 		return v.Leave(newNode)
 	}
 	n = newNode.(*FuncCallExpr)
@@ -514,12 +516,6 @@ func (n *FuncCallExpr) Accept(v Visitor) (Node, bool) {
 			return n, false
 		}
 		n.Args[i] = node.(ExprNode)
-		// in ifnull() and if() expressions,
-		// the remaining args would not be executed, so they cannot be directly folded
-		// here directly leave the expr
-		if i == 0 && (n.FnName.String() == "ifnull" || n.FnName.String() == "if") {
-			return v.Leave(n)
-		}
 	}
 	return v.Leave(n)
 }

--- a/ast/functions.go
+++ b/ast/functions.go
@@ -514,6 +514,12 @@ func (n *FuncCallExpr) Accept(v Visitor) (Node, bool) {
 			return n, false
 		}
 		n.Args[i] = node.(ExprNode)
+		// in ifnull() and if() expressions,
+		// the remaining args would not be executed, so they cannot be directly folded
+		// here directly leave the expr
+		if i == 0 && (n.FnName.String() == "ifnull" || n.FnName.String() == "if") {
+			return v.Leave(newNode)
+		}
 	}
 	return v.Leave(n)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
solve the constrant fold case in https://github.com/pingcap/tidb/pull/19367

### What is changed and how it works?
disable the constrant fold in control expressions, such as if(), ifnull() and case... when....

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test in tidb

Related changes

 - Need to cherry-pick to the release branch

