### PR TITLE
add default collation for charset in CastType

### DIFF
--- a/ast/functions_test.go
+++ b/ast/functions_test.go
@@ -190,7 +190,7 @@ func (ts *testFunctionsSuite) TestConvertCast(c *C) {
 	}{
 		{`SELECT CONVERT("abc", char(5) character set utf8)`, "utf8", "utf8_bin", ""},
 		{`SELECT CONVERT("abc", char(5))`, "utf8mb4", "utf8mb4_bin", ""},
-		{`SELECT CONVERT("abc", char(5) character set utf9)`, "","",  `[parser:1115]Unknown character set: 'utf9'`},
+		{`SELECT CONVERT("abc", char(5) character set utf9)`, "", "", `[parser:1115]Unknown character set: 'utf9'`},
 	}
 	for _, testCase := range cases {
 		stmt, err := parser.New().ParseOneStmt(testCase.SQL, "", "")

--- a/parser.y
+++ b/parser.y
@@ -6841,6 +6841,8 @@ CastType:
 		if x.Charset == "" {
 			x.Charset = mysql.DefaultCharset
 			x.Collate = mysql.DefaultCollationName
+		} else if x.Collate == "" {
+			x.Collate, _ = charset.GetDefaultCollation(x.Charset)
 		}
 		$$ = x
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

add default collation for charset
### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code
