### PR TITLE
Fix syntax error caused by unexpected hint

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -3037,6 +3037,11 @@ func (s *testParserSuite) TestHintError(c *C) {
 	stmt, _, err = parser.Parse("insert /*+ memory_quota(1 MB) */ into t select * from t;", "", "")
 	c.Assert(err, IsNil)
 	c.Assert(len(stmt[0].(*ast.InsertStmt).TableHints), Equals, 1)
+
+	stmt, warns, err = parser.Parse("SELECT id FROM tbl WHERE id = 0 FOR UPDATE /*+ xyz */", "", "")
+	c.Assert(err, IsNil)
+	c.Assert(len(warns), Equals, 1)
+	c.Assert(warns[0], ErrorMatches, `You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use near '/*+' at line 1`)
 }
 
 func (s *testParserSuite) TestErrorMsg(c *C) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -3041,7 +3041,7 @@ func (s *testParserSuite) TestHintError(c *C) {
 	stmt, warns, err = parser.Parse("SELECT id FROM tbl WHERE id = 0 FOR UPDATE /*+ xyz */", "", "")
 	c.Assert(err, IsNil)
 	c.Assert(len(warns), Equals, 1)
-	c.Assert(warns[0], ErrorMatches, `You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use near '/\*\+' at line 1`)
+	c.Assert(warns[0], ErrorMatches, `.*near '/\*\+' at line 1`)
 }
 
 func (s *testParserSuite) TestErrorMsg(c *C) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -3041,7 +3041,7 @@ func (s *testParserSuite) TestHintError(c *C) {
 	stmt, warns, err = parser.Parse("SELECT id FROM tbl WHERE id = 0 FOR UPDATE /*+ xyz */", "", "")
 	c.Assert(err, IsNil)
 	c.Assert(len(warns), Equals, 1)
-	c.Assert(warns[0], ErrorMatches, `You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use near '/*+' at line 1`)
+	c.Assert(warns[0], ErrorMatches, `You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use near '/\*\+' at line 1`)
 }
 
 func (s *testParserSuite) TestErrorMsg(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #987 

### What is changed and how it works?

Added a look back token to filter out special case `FOR UPDATE` which might mistakenly take the comment after as a optimization hint.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

 - Increased code complexity
 
Related changes

N/A