### PR TITLE
support global kill

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -752,14 +752,14 @@ type KillStmt struct {
 	// If Query is false, terminates the connection associated with the given ConnectionID, after terminating any statement the connection is executing.
 	Query        bool
 	ConnectionID uint64
-	// TiDBExtension is used to indicate whether the user knows he is sending kill statement to the right tidb-server.
+	// TiDBExtension is deprecated, and has no effect. See TiDB issue #8854.
+	// It had been used to indicate whether the user knows he is sending kill statement to the right tidb-server.
 	// When the SQL grammar is "KILL TIDB [CONNECTION | QUERY] connectionID", TiDBExtension will be set.
 	// It's a special grammar extension in TiDB. This extension exists because, when the connection is:
 	// client -> LVS proxy -> TiDB, and type Ctrl+C in client, the following action will be executed:
 	// new a connection; kill xxx;
 	// kill command may send to the wrong TiDB, because the exists of LVS proxy, and kill the wrong session.
 	// So, "KILL TIDB" grammar is introduced, and it REQUIRES DIRECT client -> TiDB TOPOLOGY.
-	// TODO: The standard KILL grammar will be supported once we have global connectionID.
 	TiDBExtension bool
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Issue Number: close pingcap/tidb#8854

Problem Summary:
Support CTRL-C or KILL to kill a connection/query.

### What is changed and how it works?
Compose a global unique connection id by a unique server id and local unique connection id. See [design doc](https://github.com/pingyu/tidb/blob/executor_global_kill/docs/design/2020-06-01-global-kill.md) and pingcap/tidb#17649 for detail.

This PR fix comment of `TiDBExtension` for consistence.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
