### PR TITLE
yy_parser: use the default SQL mode when create a new parser.

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/pingcap/parser/format"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/parser/opcode"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/parser/test_driver"
 )
@@ -5371,4 +5372,16 @@ func (s *testParserSuite) TestStatisticsOps(c *C) {
 	c.Assert(v.Columns[0].Name, Equals, model.CIStr{O: "a", L: "a"})
 	c.Assert(v.Columns[1].Name, Equals, model.CIStr{O: "b", L: "b"})
 	c.Assert(v.Columns[2].Name, Equals, model.CIStr{O: "c", L: "c"})
+}
+
+func (s *testParserSuite) TestHighNotPrecedenceMode(c *C) {
+	p := parser.New()
+
+	sms, _, err := p.Parse("SELECT NOT 1 BETWEEN -5 AND 5", "", "")
+	c.Assert(err, IsNil)
+	v, ok := sms[0].(*ast.SelectStmt)
+	c.Assert(ok, IsTrue)
+	v1, ok := v.Fields.Fields[0].Expr.(*ast.UnaryOperationExpr)
+	c.Assert(ok, IsTrue)
+	c.Assert(v1.Op, Equals, opcode.Not)
 }

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -86,7 +86,7 @@ type stmtTexter interface {
 	stmtText() string
 }
 
-// New returns a Parser object.
+// New returns a Parser object with default SQL mode.
 func New() *Parser {
 	if ast.NewValueExpr == nil ||
 		ast.NewParamMarkerExpr == nil ||
@@ -99,6 +99,8 @@ func New() *Parser {
 		cache: make([]yySymType, 200),
 	}
 	p.EnableWindowFunc(true)
+	mode, _ := mysql.GetSQLMode(mysql.DefaultSQLMode)
+	p.SetSQLMode(mode)
 	return p
 }
 


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Refer to https://github.com/pingcap/tidb/issues/17791.

### What is changed and how it works?
Set SQL mode to the default mode.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change

Side effects



Related changes

 - Need to cherry-pick to the release branch

