### PR TITLE
fix CreateTablespacePriv order in const

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -211,6 +211,8 @@ const (
 	SuperPriv
 	// CreateUserPriv is the privilege to create user.
 	CreateUserPriv
+	// CreateTablespacePriv is the privilege to create tablespace.
+	CreateTablespacePriv
 	// TriggerPriv is not checked yet.
 	TriggerPriv
 	// DropPriv is the privilege to drop schema/table.

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -211,8 +211,6 @@ const (
 	SuperPriv
 	// CreateUserPriv is the privilege to create user.
 	CreateUserPriv
-	// CreateTablespacePriv is the privilege to create tablespace.
-	CreateTablespacePriv
 	// TriggerPriv is not checked yet.
 	TriggerPriv
 	// DropPriv is the privilege to drop schema/table.

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -256,6 +256,9 @@ const (
 
 	// AllPriv is the privilege for all actions.
 	AllPriv
+	/*
+	 *  Please add the new priv before AllPriv to keep the values consistent across versions.
+	 */
 )
 
 // AllPrivMask is the mask for PrivilegeType with all bits set to 1.

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -251,11 +251,11 @@ const (
 	// ConfigPriv is the privilege to enable the use SET CONFIG statements.
 	ConfigPriv
 
-	// AllPriv is the privilege for all actions.
-	AllPriv
-
 	// CreateTablespacePriv is the privilege to create tablespace.
 	CreateTablespacePriv
+
+	// AllPriv is the privilege for all actions.
+	AllPriv
 )
 
 // AllPrivMask is the mask for PrivilegeType with all bits set to 1.


### PR DESCRIPTION
### What problem does this PR solve?
Tidb does not start properly with error `[error="[privilege:8049]mysql.user"]`.

### What is changed and how it works?
Adjust the order of CreateTablespacePriv.

### Check List

Tests

