### PR TITLE
ast: reset JoinLevel at the beginning of TableRefsClause.Restore

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -615,6 +615,11 @@ type TableRefsClause struct {
 
 // Restore implements Node interface.
 func (n *TableRefsClause) Restore(ctx *format.RestoreCtx) error {
+	level := ctx.JoinLevel
+	ctx.JoinLevel = 0
+	defer func() {
+		ctx.JoinLevel = level
+	}()
 	if err := n.TableRefs.Restore(ctx); err != nil {
 		return errors.Annotate(err, "An error occurred while restore TableRefsClause.TableRefs")
 	}

--- a/ast/dml_test.go
+++ b/ast/dml_test.go
@@ -234,6 +234,7 @@ func (ts *testDMLSuite) TestTableRefsClauseRestore(c *C) {
 		{"t", "`t`"},
 		{"t1 join t2", "`t1` JOIN `t2`"},
 		{"t1, t2", "(`t1`) JOIN `t2`"},
+		{"(select * from (select * from t1) as tmp) as tmp", "(SELECT * FROM (SELECT * FROM `t1`) AS `tmp`) AS `tmp`"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*SelectStmt).From


### PR DESCRIPTION
Signed-off-by: hexilee <i@hexilee.me>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Currently, `format.RestoreCtx.JoinLevel` does not work well in the multi-level subquery. 
If you parse the following SQL and restore it, you will get unnecessary pairs of parentheses in the inner subquery.

```SQL
-- origin
SELECT * FROM (SELECT * FROM (SELECT * FROM `t1`) AS `tmp`) AS `tmp`
```

```SQL
-- restored
SELECT * FROM (SELECT * FROM ((SELECT * FROM (`t1`)) AS `tmp`)) AS `tmp`
```

Unnecessary parentheses can be ignored by tidb. However, in mysql, it will cause a syntax error.

```log
mysql 8.0.21

mysql root@127.0.0.1:test> select * from (SELECT * FROM ((SELECT * FROM (`t1`)) AS `tmp`)) AS `tmp`;
(1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')) AS `tmp`' at line 1")
```

### What is changed and how it works?
This PR reset `JoinLevel` at the beginning of `TableRefsClause.Restore`, then `JoinLevel` will never affect subquery.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has interface methods change
