### PR TITLE
parser: support alter sequence

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -2040,14 +2040,13 @@ const (
 	SequenceCycle
 	// SequenceRestart is only used in alter sequence statement.
 	SequenceRestart
+	SequenceRestartWith
 )
 
 // SequenceOption is used for parsing sequence option from SQL.
 type SequenceOption struct {
 	Tp       SequenceOptionType
 	IntValue int64
-	// SequenceRestart is only used for restart option in alter sequence statement.
-	NoValue bool
 }
 
 func (n *SequenceOption) Restore(ctx *format.RestoreCtx) error {
@@ -2079,10 +2078,9 @@ func (n *SequenceOption) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord("CYCLE")
 	case SequenceRestart:
 		ctx.WriteKeyWord("RESTART")
-		if !n.NoValue {
-			ctx.WriteKeyWord(" ")
-			ctx.WritePlainf("%d", n.IntValue)
-		}
+	case SequenceRestartWith:
+		ctx.WriteKeyWord("RESTART WITH ")
+		ctx.WritePlainf("%d", n.IntValue)
 	default:
 		return errors.Errorf("invalid SequenceOption: %d", n.Tp)
 	}

--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -3581,7 +3581,6 @@ func (n *AlterSequenceStmt) Restore(ctx *format.RestoreCtx) error {
 		}
 	}
 	return nil
-
 }
 
 func (n *AlterSequenceStmt) Accept(v Visitor) (Node, bool) {

--- a/misc.go
+++ b/misc.go
@@ -557,6 +557,7 @@ var tokenMap = map[string]int{
 	"REQUIRE":                  require,
 	"RESET":                    reset,
 	"RESPECT":                  respect,
+	"RESTART":                  restart,
 	"RESTORE":                  restore,
 	"RESTORES":                 restores,
 	"RESTRICT":                 restrict,

--- a/parser.y
+++ b/parser.y
@@ -501,6 +501,7 @@ import (
 	replicas              "REPLICAS"
 	replication           "REPLICATION"
 	respect               "RESPECT"
+	restart               "RESTART"
 	restore               "RESTORE"
 	restores              "RESTORES"
 	reverse               "REVERSE"
@@ -788,6 +789,7 @@ import (
 	AlterTableStmt       "Alter table statement"
 	AlterUserStmt        "Alter user statement"
 	AlterInstanceStmt    "Alter instance statement"
+	AlterSequenceStmt    "Alter sequence statement"
 	AnalyzeTableStmt     "Analyze table statement"
 	BeginTransactionStmt "BEGIN TRANSACTION statement"
 	BinlogStmt           "Binlog base64 statement"
@@ -864,6 +866,8 @@ import (
 	AlterTableSpec                         "Alter table specification"
 	AlterTableSpecList                     "Alter table specification list"
 	AlterTableSpecListOpt                  "Alter table specification list optional"
+	AlterSequenceOption                    "Alter sequence option"
+	AlterSequenceOptionList                "Alter sequence option list"
 	AnalyzeOption                          "Analyze option"
 	AnalyzeOptionList                      "Analyze option list"
 	AnalyzeOptionListOpt                   "Optional analyze option list"
@@ -5155,6 +5159,7 @@ UnReservedKeyword:
 |	"REBUILD"
 |	"REDUNDANT"
 |	"REORGANIZE"
+|	"RESTART"
 |	"ROLE"
 |	"ROLLBACK"
 |	"SESSION"
@@ -9621,6 +9626,7 @@ Statement:
 |	AlterTableStmt
 |	AlterUserStmt
 |	AlterInstanceStmt
+|	AlterSequenceStmt
 |	AnalyzeTableStmt
 |	BeginTransactionStmt
 |	BinlogStmt
@@ -11967,6 +11973,41 @@ DropSequenceStmt:
 			IfExists:  $3.(bool),
 			Sequences: $4.([]*ast.TableName),
 		}
+	}
+
+AlterSequenceStmt:
+	"ALTER" "SEQUENCE" IfExists TableName AlterSequenceOptionList
+	{
+		$$ = &ast.AlterSequenceStmt{
+			IfExists:   $3.(bool),
+			Name:       $4.(*ast.TableName),
+			SeqOptions: $5.([]*ast.SequenceOption),
+		}
+	}
+
+AlterSequenceOptionList:
+	AlterSequenceOption
+	{
+		$$ = []*ast.SequenceOption{$1.(*ast.SequenceOption)}
+	}
+|	AlterSequenceOptionList AlterSequenceOption
+	{
+		$$ = append($1.([]*ast.SequenceOption), $2.(*ast.SequenceOption))
+	}
+
+AlterSequenceOption:
+	SequenceOption
+|	"RESTART"
+	{
+		$$ = &ast.SequenceOption{Tp: ast.SequenceRestart, NoValue: true}
+	}
+|	"RESTART" EqOpt SignedNum
+	{
+		$$ = &ast.SequenceOption{Tp: ast.SequenceRestart, IntValue: $3.(int64)}
+	}
+|	"RESTART" "WITH" SignedNum
+	{
+		$$ = &ast.SequenceOption{Tp: ast.SequenceRestart, IntValue: $3.(int64)}
 	}
 
 /********************************************************************

--- a/parser.y
+++ b/parser.y
@@ -12013,15 +12013,15 @@ AlterSequenceOption:
 	SequenceOption
 |	"RESTART"
 	{
-		$$ = &ast.SequenceOption{Tp: ast.SequenceRestart, NoValue: true}
+		$$ = &ast.SequenceOption{Tp: ast.SequenceRestart}
 	}
 |	"RESTART" EqOpt SignedNum
 	{
-		$$ = &ast.SequenceOption{Tp: ast.SequenceRestart, IntValue: $3.(int64)}
+		$$ = &ast.SequenceOption{Tp: ast.SequenceRestartWith, IntValue: $3.(int64)}
 	}
 |	"RESTART" "WITH" SignedNum
 	{
-		$$ = &ast.SequenceOption{Tp: ast.SequenceRestart, IntValue: $3.(int64)}
+		$$ = &ast.SequenceOption{Tp: ast.SequenceRestartWith, IntValue: $3.(int64)}
 	}
 
 /********************************************************************

--- a/parser.y
+++ b/parser.y
@@ -11975,6 +11975,20 @@ DropSequenceStmt:
 		}
 	}
 
+/********************************************************************************************
+ *
+ *  Alter Sequence Statement
+ *
+ *  Example:
+ *	ALTER SEQUENCE [IF EXISTS] sequence_name
+ *	[ INCREMENT [ BY | = ] increment ]
+ *	[ MINVALUE [=] minvalue | NO MINVALUE | NOMINVALUE ]
+ *	[ MAXVALUE [=] maxvalue | NO MAXVALUE | NOMAXVALUE ]
+ *	[ START [ WITH | = ] start ]
+ *	[ CACHE [=] cache | NOCACHE | NO CACHE]
+ *	[ CYCLE | NOCYCLE | NO CYCLE]
+ *	[ RESTART [WITH | = ] start ]
+ ********************************************************************************************/
 AlterSequenceStmt:
 	"ALTER" "SEQUENCE" IfExists TableName AlterSequenceOptionList
 	{

--- a/parser.y
+++ b/parser.y
@@ -11987,7 +11987,7 @@ DropSequenceStmt:
  *	[ START [ WITH | = ] start ]
  *	[ CACHE [=] cache | NOCACHE | NO CACHE]
  *	[ CYCLE | NOCYCLE | NO CYCLE]
- *	[ RESTART [WITH | = ] start ]
+ *	[ RESTART [WITH | = ] restart ]
  ********************************************************************************************/
 AlterSequenceStmt:
 	"ALTER" "SEQUENCE" IfExists TableName AlterSequenceOptionList

--- a/parser_test.go
+++ b/parser_test.go
@@ -3076,6 +3076,8 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"alter sequence if exists seq2 increment = 2", true, "ALTER SEQUENCE IF EXISTS `seq2` INCREMENT BY 2"},
 		{"alter sequence seq restart", true, "ALTER SEQUENCE `seq` RESTART"},
 		{"alter sequence seq start with 3 restart with 5", true, "ALTER SEQUENCE `seq` START WITH 3 RESTART WITH 5"},
+		{"alter sequence seq restart = 5", true, "ALTER SEQUENCE `seq` RESTART WITH 5"},
+		{"create sequence seq restart = 5", false, ""},
 	}
 	s.RunTest(c, table)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -3065,6 +3065,17 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"create table t (a bigint primary key auto_random(4), b varchar(100)) auto_random_base 200", true, "CREATE TABLE `t` (`a` BIGINT PRIMARY KEY AUTO_RANDOM(4),`b` VARCHAR(100)) AUTO_RANDOM_BASE = 200"},
 		{"alter table t auto_random_base = 50", true, "ALTER TABLE `t` AUTO_RANDOM_BASE = 50"},
 		{"alter table t auto_increment 30, auto_random_base 40", true, "ALTER TABLE `t` AUTO_INCREMENT = 30, AUTO_RANDOM_BASE = 40"},
+
+		// for alter sequence
+		{"alter sequence seq", false, ""},
+		{"alter sequence seq comment=\"haha\"", false, ""},
+		{"alter sequence seq start = 1", true, "ALTER SEQUENCE `seq` START WITH 1"},
+		{"alter sequence seq start with 1 increment by 1", true, "ALTER SEQUENCE `seq` START WITH 1 INCREMENT BY 1"},
+		{"alter sequence seq start with 1 increment by 2 minvalue 0 maxvalue 100", true, "ALTER SEQUENCE `seq` START WITH 1 INCREMENT BY 2 MINVALUE 0 MAXVALUE 100"},
+		{"alter sequence seq increment -1 start with -1 minvalue -1 maxvalue -1000 cache = 10 nocycle", true, "ALTER SEQUENCE `seq` INCREMENT BY -1 START WITH -1 MINVALUE -1 MAXVALUE -1000 CACHE 10 NOCYCLE"},
+		{"alter sequence if exists seq2 increment = 2", true, "ALTER SEQUENCE IF EXISTS `seq2` INCREMENT BY 2"},
+		{"alter sequence seq restart", true, "ALTER SEQUENCE `seq` RESTART"},
+		{"alter sequence seq start with 3 restart with 5", true, "ALTER SEQUENCE `seq` START WITH 3 RESTART 5"},
 	}
 	s.RunTest(c, table)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -3075,7 +3075,7 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"alter sequence seq increment -1 start with -1 minvalue -1 maxvalue -1000 cache = 10 nocycle", true, "ALTER SEQUENCE `seq` INCREMENT BY -1 START WITH -1 MINVALUE -1 MAXVALUE -1000 CACHE 10 NOCYCLE"},
 		{"alter sequence if exists seq2 increment = 2", true, "ALTER SEQUENCE IF EXISTS `seq2` INCREMENT BY 2"},
 		{"alter sequence seq restart", true, "ALTER SEQUENCE `seq` RESTART"},
-		{"alter sequence seq start with 3 restart with 5", true, "ALTER SEQUENCE `seq` START WITH 3 RESTART 5"},
+		{"alter sequence seq start with 3 restart with 5", true, "ALTER SEQUENCE `seq` START WITH 3 RESTART WITH 5"},
 	}
 	s.RunTest(c, table)
 }


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Try to support `alter sequence`.
The syntax here is compatible with oracle, the additional `restart` syntax is borrowed from MariaDB which could reset a sequence quickly when altering a sequence rather than dropping it and creating a new one.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to update the documentation
 - Need to be included in the release note
