### PR TITLE
model: add extract-expr cache in PartitionInfo

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -744,6 +745,28 @@ type PartitionInfo struct {
 	// DroppingDefinitions is filled when dropping a partition that is in the mid state.
 	DroppingDefinitions []PartitionDefinition `json:"dropping_definitions"`
 	Num                 uint64                `json:"num"`
+
+	// ByExprCache is filled when first time get partition expr.
+	ByExprCache struct {
+		sync.Once
+		// Items will be assign []expression.Expression, but use interface{} to reduce cycle.
+		Items interface{}
+	} `json:"-"`
+}
+
+// Clone clones partition info.
+// it doesn't copy sync.Once or cached value.
+func (pi *PartitionInfo) Clone() *PartitionInfo {
+	return &PartitionInfo{
+		Type:                pi.Type,
+		Expr:                pi.Expr,
+		Columns:             pi.Columns,
+		Enable:              pi.Enable,
+		Definitions:         pi.Definitions,
+		AddingDefinitions:   pi.AddingDefinitions,
+		DroppingDefinitions: pi.DroppingDefinitions,
+		Num:                 pi.Num,
+	}
 }
 
 // GetNameByID gets the partition name by ID.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

help https://github.com/pingcap/tidb/pull/20435

### What is changed and how it works?

add a ExtractExprCache items, it should not serialize in json result.

and also add a Clone method to avoid "copy sync.Once" problem.
 
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test in tidb

Code changes

 - n/a

Side effects

 - n/a

Related changes

 - n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/parser/1054)
<!-- Reviewable:end -->
