### PR TITLE
ast: Don't write comma when restore TableOption of ALTER TABLE

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -2353,7 +2353,7 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 		default:
 			for i, opt := range n.Options {
 				if i != 0 {
-					ctx.WritePlain(", ")
+					ctx.WritePlain(" ")
 				}
 				if err := opt.Restore(ctx); err != nil {
 					return errors.Annotatef(err, "An error occurred while restore AlterTableSpec.Options[%d]", i)

--- a/ast/ddl_test.go
+++ b/ast/ddl_test.go
@@ -523,6 +523,17 @@ func (ts *testDDLSuite) TestAlterTableSpecRestore(c *C) {
 	RunNodeRestoreTest(c, testCases, "ALTER TABLE t %s", extractNodeFunc)
 }
 
+func (ts *testDDLSuite) TestAlterTableOptionRestore(c *C) {
+	testCases := []NodeRestoreTestCase{
+		{"ALTER TABLE t ROW_FORMAT = COMPRESSED KEY_BLOCK_SIZE = 8", "ALTER TABLE `t` ROW_FORMAT = COMPRESSED KEY_BLOCK_SIZE = 8"},
+		{"ALTER TABLE t ROW_FORMAT = COMPRESSED, KEY_BLOCK_SIZE = 8", "ALTER TABLE `t` ROW_FORMAT = COMPRESSED, KEY_BLOCK_SIZE = 8"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node
+	}
+	RunNodeRestoreTest(c, testCases, "%s", extractNodeFunc)
+}
+
 func (ts *testDDLSuite) TestAdminRepairTableRestore(c *C) {
 	testCases := []NodeRestoreTestCase{
 		{"ADMIN REPAIR TABLE t CREATE TABLE t (a int)", "ADMIN REPAIR TABLE `t` CREATE TABLE `t` (`a` INT)"},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
it's optional to write a comma between `table_option`

https://dev.mysql.com/doc/refman/5.7/en/alter-table.html

if we write it default, a single schema change DDL will become multi-schema change DDL as in https://github.com/pingcap/dm/issues/1175#issuecomment-709900540

### What is changed and how it works?
don't write comma

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

 - Breaking backward compatibility (?)

Related changes
