### PR TITLE
parser.y: allow subquery without table alias syntax-checked (#968)

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -7510,7 +7510,7 @@ TableFactor:
 		tn.IndexHints = $4.([]*ast.IndexHint)
 		$$ = &ast.TableSource{Source: tn, AsName: $3.(model.CIStr)}
 	}
-|	'(' SelectStmt ')' TableAsName
+|	'(' SelectStmt ')' TableAsNameOpt
 	{
 		st := $2.(*ast.SelectStmt)
 		endOffset := parser.endOffset(&yyS[yypt-1])

--- a/parser_test.go
+++ b/parser_test.go
@@ -756,6 +756,10 @@ func (s *testParserSuite) TestDMLStmt(c *C) {
 		// for https://github.com/pingcap/tidb/issues/320
 		{`(select 1);`, true, "SELECT 1"},
 
+		// for https://github.com/pingcap/parser/issues/963
+		{"select min(b) b from (select min(t.b) b from t where t.a = '');", true, "SELECT MIN(`b`) AS `b` FROM (SELECT MIN(`t`.`b`) AS `b` FROM (`t`) WHERE `t`.`a`='')"},
+		{"select min(b) b from (select min(t.b) b from t where t.a = '') as t1;", true, "SELECT MIN(`b`) AS `b` FROM (SELECT MIN(`t`.`b`) AS `b` FROM (`t`) WHERE `t`.`a`='') AS `t1`"},
+
 		// for https://github.com/pingcap/tidb/issues/1050
 		{`SELECT /*!40001 SQL_NO_CACHE */ * FROM test WHERE 1 limit 0, 2000;`, true, "SELECT SQL_NO_CACHE * FROM `test` WHERE 1 LIMIT 0,2000"},
 


### PR DESCRIPTION
Cherry-pick #968 to release-4.0.