### PR TITLE
*: tiny optimize for huge partition table (#1072)

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -711,9 +711,12 @@ type PartitionInfo struct {
 
 // GetNameByID gets the partition name by ID.
 func (pi *PartitionInfo) GetNameByID(id int64) string {
-	for _, def := range pi.Definitions {
-		if id == def.ID {
-			return def.Name.L
+	definitions := pi.Definitions
+	// do not convert this loop to `for _, def := range definitions`.
+	// see https://github.com/pingcap/parser/pull/1072 for the benchmark.
+	for i := range definitions {
+		if id == definitions[i].ID {
+			return definitions[i].Name.L
 		}
 	}
 	return ""
@@ -738,8 +741,9 @@ func (ci *PartitionDefinition) Clone() PartitionDefinition {
 // FindPartitionDefinitionByName finds PartitionDefinition by name.
 func (t *TableInfo) FindPartitionDefinitionByName(partitionDefinitionName string) *PartitionDefinition {
 	lowConstrName := strings.ToLower(partitionDefinitionName)
-	for i, pd := range t.Partition.Definitions {
-		if pd.Name.L == lowConstrName {
+	definitions := t.Partition.Definitions
+	for i := range definitions {
+		if definitions[i].Name.L == lowConstrName {
 			return &t.Partition.Definitions[i]
 		}
 	}


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/parser/pull/1072

Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Optimize for `runtime.duffcopy`:

![image](https://user-images.githubusercontent.com/26020263/97984162-538da080-1e11-11eb-8c89-34e725bf74cb.png)


Here is a benchmark test:

```go
func (pi *PartitionInfo) GetNameByID(id int64) string {
	definitions := pi.Definitions
	for i := range definitions {
		if id == definitions[i].ID {
			return definitions[i].Name.L
		}
	}
	return ""
}

func (pi *PartitionInfo) GetNameByIDOrigin(id int64) string {
	for _, def := range pi.Definitions {
		if id == def.ID {
			return def.Name.L
		}
	}
	return ""
}

func BenchmarkGetNameByID(b *testing.B) {
	pi := &PartitionInfo{}
	pi.Definitions = make([]PartitionDefinition, 0, 10000)
	for i := 0; i < 10000; i++ {
		pi.Definitions = append(pi.Definitions, PartitionDefinition{ID: int64(i), Name: NewCIStr(strconv.Itoa(i))})
	}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		pi.GetNameByID(int64(i % 10001))
	}
}

func BenchmarkGetNameByIDOrigin(b *testing.B) {
	pi := &PartitionInfo{}
	pi.Definitions = make([]PartitionDefinition, 0, 10000)
	for i := 0; i < 10000; i++ {
		pi.Definitions = append(pi.Definitions, PartitionDefinition{ID: int64(i), Name: NewCIStr(strconv.Itoa(i))})
	}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		pi.GetNameByIDOrigin(int64(i % 10001))
	}
}
```

The result is:

```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/parser/model
BenchmarkGetNameByID-24                   344668              3411 ns/op
BenchmarkGetNameByIDOrigin-24              48640             24093 ns/op
```


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Code changes


Side effects

 - No

Related changes

 - No

