### PR TITLE
model: fix null origin default value for bit column (#983)

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -134,7 +134,7 @@ func (c *ColumnInfo) SetOriginDefaultValue(value interface{}) error {
 
 // GetOriginalDefaultValue gets the origin default value.
 func (c *ColumnInfo) GetOriginDefaultValue() interface{} {
-	if c.Tp == mysql.TypeBit {
+	if c.Tp == mysql.TypeBit && c.OriginDefaultValueBit != nil {
 		// If the column type is BIT, both `OriginDefaultValue` and `DefaultValue` of ColumnInfo are corrupted,
 		// because the content before json.Marshal is INCONSISTENT with the content after json.Unmarshal.
 		return string(c.OriginDefaultValueBit)

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -346,6 +346,13 @@ func (testModelSuite) TestDefaultValue(c *C) {
 	err = newBitCol.SetDefaultValue(randBitStr)
 	c.Assert(newBitCol.GetDefaultValue(), Equals, randBitStr)
 
+	nullBitCol := srcCol.Clone()
+	nullBitCol.Name = NewCIStr("nullBitCol")
+	nullBitCol.FieldType = *types.NewFieldType(mysql.TypeBit)
+	err = nullBitCol.SetOriginDefaultValue(nil)
+	c.Assert(err, IsNil)
+	c.Assert(nullBitCol.GetOriginDefaultValue(), IsNil)
+
 	testCases := []struct {
 		col          *ColumnInfo
 		isConsistent bool
@@ -354,6 +361,7 @@ func (testModelSuite) TestDefaultValue(c *C) {
 		{oldBitCol, false},
 		{newPlainCol, true},
 		{newBitCol, true},
+		{nullBitCol, true},
 	}
 	for _, tc := range testCases {
 		col, isConsistent := tc.col, tc.isConsistent


### PR DESCRIPTION
Cherry-pick #983 to release-3.0.