### PR TITLE
ast: fix Restore for INL_HASH_JOIN / INL_MERGE_JOIN hints

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -2725,7 +2725,7 @@ func (n *TableOptimizerHint) Restore(ctx *format.RestoreCtx) error {
 		ctx.WritePlainf("%d", n.HintData.(uint64))
 	case "nth_plan":
 		ctx.WritePlainf("%d", n.HintData.(int64))
-	case "tidb_hj", "tidb_smj", "tidb_inlj", "hash_join", "merge_join", "inl_join", "broadcast_join", "broadcast_join_local":
+	case "tidb_hj", "tidb_smj", "tidb_inlj", "hash_join", "merge_join", "inl_join", "broadcast_join", "broadcast_join_local", "inl_hash_join", "inl_merge_join":
 		for i, table := range n.Tables {
 			if i != 0 {
 				ctx.WritePlain(", ")

--- a/ast/misc_test.go
+++ b/ast/misc_test.go
@@ -233,6 +233,8 @@ func (ts *testMiscSuite) TestTableOptimizerHintRestore(c *C) {
 		{"TIDB_HJ(t1@sel1,t2@sel2)", "TIDB_HJ(`t1`@`sel1`, `t2`@`sel2`)"},
 		{"MERGE_JOIN(t1,t2)", "MERGE_JOIN(`t1`, `t2`)"},
 		{"BROADCAST_JOIN(t1,t2)", "BROADCAST_JOIN(`t1`, `t2`)"},
+		{"INL_HASH_JOIN(t1,t2)", "INL_HASH_JOIN(`t1`, `t2`)"},
+		{"INL_MERGE_JOIN(t1,t2)", "INL_MERGE_JOIN(`t1`, `t2`)"},
 		{"INL_JOIN(t1,t2)", "INL_JOIN(`t1`, `t2`)"},
 		{"HASH_JOIN(t1,t2)", "HASH_JOIN(`t1`, `t2`)"},
 		{"MAX_EXECUTION_TIME(3000)", "MAX_EXECUTION_TIME(3000)"},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, hint `INL_HASH_JOIN(t1,t2)` would be restored as `INL_HASH_JOIN()`, which would cause `explain format = 'hint'` or baseline capture broken.

### What is changed and how it works?

Restore table parameters for these 2 kinds of hints.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

N/A

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
