### PR TITLE
mysql: fix wrong default decimal length

### DIFF
--- a/mysql/util.go
+++ b/mysql/util.go
@@ -29,7 +29,7 @@ var defaultLengthAndDecimal = map[byte]lengthAndDecimal{
 	TypeLonglong:   {20, 0},
 	TypeDouble:     {22, -1},
 	TypeFloat:      {12, -1},
-	TypeNewDecimal: {11, 0},
+	TypeNewDecimal: {10, 0},
 	TypeDuration:   {10, 0},
 	TypeDate:       {10, 0},
 	TypeTimestamp:  {19, 0},


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?

For https://github.com/pingcap/tidb/issues/11327
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes



Side effects



Related changes

 - Need to cherry-pick to the release branch