### PR TITLE
*: add alter table read only/write support

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -2160,6 +2160,7 @@ const (
 	AlterTableRenameTable
 	AlterTableAlterColumn
 	AlterTableLock
+	AlterTableWriteable
 	AlterTableAlgorithm
 	AlterTableRenameIndex
 	AlterTableForce
@@ -2291,6 +2292,7 @@ type AlterTableSpec struct {
 	Visibility      IndexVisibility
 	TiFlashReplica  *TiFlashReplicaSpec
 	PlacementSpecs  []*PlacementSpec
+	Writeable       bool
 }
 
 type TiFlashReplicaSpec struct {
@@ -2497,6 +2499,13 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord("LOCK ")
 		ctx.WritePlain("= ")
 		ctx.WriteKeyWord(n.LockType.String())
+	case AlterTableWriteable:
+		ctx.WriteKeyWord("READ ")
+		if n.Writeable {
+			ctx.WriteKeyWord("WRITE")
+		} else {
+			ctx.WriteKeyWord("ONLY")
+		}
 	case AlterTableOrderByColumns:
 		ctx.WriteKeyWord("ORDER BY ")
 		for i, alterOrderItem := range n.OrderByList {

--- a/model/model.go
+++ b/model/model.go
@@ -386,6 +386,9 @@ const (
 	TableLockRead
 	// TableLockReadLocal is not supported.
 	TableLockReadLocal
+	// TableLockReadOnly is used to set a table into read-only status,
+	// when the session exits, it will not release its lock automatically.
+	TableLockReadOnly
 	// TableLockWrite means only the session with this lock has write/read permission.
 	// Only the session that holds the lock can access the table. No other session can access it until the lock is released.
 	TableLockWrite
@@ -401,6 +404,8 @@ func (t TableLockType) String() string {
 		return "READ"
 	case TableLockReadLocal:
 		return "READ LOCAL"
+	case TableLockReadOnly:
+		return "READ ONLY"
 	case TableLockWriteLocal:
 		return "WRITE LOCAL"
 	case TableLockWrite:

--- a/parser.y
+++ b/parser.y
@@ -1397,6 +1397,19 @@ AlterTableStmt:
 			AnalyzeOpts:    $10.([]ast.AnalyzeOpt),
 		}
 	}
+|	"ALTER" IgnoreOptional "TABLE" TableName "READ" "WRITE"
+	{
+		$$ = &ast.CleanupTableLockStmt{
+			Tables: $4.(*ast.TableName),
+		}
+	}
+|	"ALTER" IgnoreOptional "TABLE" TableName "READ" "ONLY"
+	{
+		$$ = ast.TableLock{
+			Table: $4.(*ast.TableName),
+			Type:  model.TableLockReadOnly,
+		}
+	}
 
 PlacementRole:
 	"ROLE" "=" "FOLLOWER"
@@ -11945,10 +11958,6 @@ LockType:
 |	"READ" "LOCAL"
 	{
 		$$ = model.TableLockReadLocal
-	}
-|	"READ" "ONLY"
-	{
-		$$ = model.TableLockReadOnly
 	}
 |	"WRITE"
 	{

--- a/parser.y
+++ b/parser.y
@@ -1143,6 +1143,7 @@ import (
 	WithGrantOptionOpt                     "With Grant Option opt"
 	WithValidation                         "with validation"
 	WithValidationOpt                      "optional with validation"
+	Writeable                              "Table writeable status"
 	ElseOpt                                "Optional else clause"
 	Type                                   "Types"
 	OptExistingWindowName                  "Optional existing WINDOW name"
@@ -1395,19 +1396,6 @@ AlterTableStmt:
 			IndexNames:     $9.([]model.CIStr),
 			IndexFlag:      true,
 			AnalyzeOpts:    $10.([]ast.AnalyzeOpt),
-		}
-	}
-|	"ALTER" IgnoreOptional "TABLE" TableName "READ" "WRITE"
-	{
-		$$ = &ast.CleanupTableLockStmt{
-			Tables: []*ast.TableName{$4.(*ast.TableName)},
-		}
-	}
-|	"ALTER" IgnoreOptional "TABLE" TableName "READ" "ONLY"
-	{
-		$$ = ast.TableLock{
-			Table: $4.(*ast.TableName),
-			Type:  model.TableLockReadOnly,
 		}
 	}
 
@@ -1969,6 +1957,13 @@ AlterTableSpec:
 			LockType: $1.(ast.LockType),
 		}
 	}
+|	Writeable
+	{
+		$$ = &ast.AlterTableSpec{
+			Tp:        ast.AlterTableWriteable,
+			Writeable: $1.(bool),
+		}
+	}
 |	AlgorithmClause
 	{
 		// Parse it and ignore it. Just for compatibility.
@@ -2140,6 +2135,16 @@ LockClause:
 			yylex.AppendError(ErrUnknownAlterLock.GenWithStackByArgs($3))
 			return 1
 		}
+	}
+
+Writeable:
+	"READ" "WRITE"
+	{
+		$$ = true
+	}
+|	"READ" "ONLY"
+	{
+		$$ = false
 	}
 
 KeyOrIndex:

--- a/parser.y
+++ b/parser.y
@@ -11946,6 +11946,10 @@ LockType:
 	{
 		$$ = model.TableLockReadLocal
 	}
+|	"READ" "ONLY"
+	{
+		$$ = model.TableLockReadOnly
+	}
 |	"WRITE"
 	{
 		$$ = model.TableLockWrite

--- a/parser.y
+++ b/parser.y
@@ -1400,7 +1400,7 @@ AlterTableStmt:
 |	"ALTER" IgnoreOptional "TABLE" TableName "READ" "WRITE"
 	{
 		$$ = &ast.CleanupTableLockStmt{
-			Tables: $4.(*ast.TableName),
+			Tables: []*ast.TableName{$4.(*ast.TableName)},
 		}
 	}
 |	"ALTER" IgnoreOptional "TABLE" TableName "READ" "ONLY"

--- a/parser_test.go
+++ b/parser_test.go
@@ -4144,8 +4144,8 @@ func (s *testParserSuite) TestLockUnlockTables(c *C) {
 		{"ADMIN CLEANUP TABLE LOCK t1,t2", true, "ADMIN CLEANUP TABLE LOCK `t1`, `t2`"},
 
 		// For alter table read only/write.
-		{"ALTER TABLE t READ ONLY", true, "ALTER TABLE t READ ONLY"},
-		{"ALTER TABLE t READ WRITE", true, "ALTER TABLE t READ WRITE"},
+		{"ALTER TABLE t READ ONLY", true, "ALTER TABLE `t` READ ONLY"},
+		{"ALTER TABLE t READ WRITE", true, "ALTER TABLE `t` READ WRITE"},
 	}
 	s.RunTest(c, table)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -4123,6 +4123,7 @@ func (s *testParserSuite) TestLockUnlockTables(c *C) {
 		{`UNLOCK TABLES;`, true, "UNLOCK TABLES"},
 		{`LOCK TABLES t1 READ;`, true, "LOCK TABLES `t1` READ"},
 		{`LOCK TABLES t1 READ LOCAL;`, true, "LOCK TABLES `t1` READ LOCAL"},
+		{`LOCK TABLES t1 READ ONLY;`, true, "LOCK TABLES `t1` READ ONLY"},
 		{`show table status like 't'`, true, "SHOW TABLE STATUS LIKE 't'"},
 		{`LOCK TABLES t2 WRITE`, true, "LOCK TABLES `t2` WRITE"},
 		{`LOCK TABLES t2 WRITE LOCAL;`, true, "LOCK TABLES `t2` WRITE LOCAL"},

--- a/parser_test.go
+++ b/parser_test.go
@@ -4123,7 +4123,6 @@ func (s *testParserSuite) TestLockUnlockTables(c *C) {
 		{`UNLOCK TABLES;`, true, "UNLOCK TABLES"},
 		{`LOCK TABLES t1 READ;`, true, "LOCK TABLES `t1` READ"},
 		{`LOCK TABLES t1 READ LOCAL;`, true, "LOCK TABLES `t1` READ LOCAL"},
-		{`LOCK TABLES t1 READ ONLY;`, true, "LOCK TABLES `t1` READ ONLY"},
 		{`show table status like 't'`, true, "SHOW TABLE STATUS LIKE 't'"},
 		{`LOCK TABLES t2 WRITE`, true, "LOCK TABLES `t2` WRITE"},
 		{`LOCK TABLES t2 WRITE LOCAL;`, true, "LOCK TABLES `t2` WRITE LOCAL"},
@@ -4143,6 +4142,10 @@ func (s *testParserSuite) TestLockUnlockTables(c *C) {
 		{"ADMIN CLEANUP TABLE LOCK", false, ""},
 		{"ADMIN CLEANUP TABLE LOCK t", true, "ADMIN CLEANUP TABLE LOCK `t`"},
 		{"ADMIN CLEANUP TABLE LOCK t1,t2", true, "ADMIN CLEANUP TABLE LOCK `t1`, `t2`"},
+
+		// For alter table read only/write.
+		{"ALTER TABLE t READ ONLY", true, "ALTER TABLE t READ ONLY"},
+		{"ALTER TABLE t READ WRITE", true, "ALTER TABLE t READ WRITE"},
 	}
 	s.RunTest(c, table)
 }


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR intends to support Oracle like `alter table read only/write` syntax. It is used to do not release locks automatically when the session exits. Which will make the memory cache easy to effect. Related to https://github.com/pingcap/tidb/pull/20396

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
