### PR TITLE
digester: consider paramMarker as literal when normalizing SQL (#1040)

### DIFF
--- a/digester.go
+++ b/digester.go
@@ -331,7 +331,7 @@ func (d *sqlDigester) isStarParam() (starParam bool) {
 
 func (d *sqlDigester) isLit(t token) (beLit bool) {
 	tok := t.tok
-	if d.isNumLit(tok) || tok == stringLit || tok == bitLit {
+	if d.isNumLit(tok) || tok == stringLit || tok == bitLit || tok == paramMarker {
 		beLit = true
 	} else if t.lit == "*" {
 		beLit = true

--- a/digester_test.go
+++ b/digester_test.go
@@ -52,6 +52,8 @@ func (s *testSQLDigestSuite) TestNormalize(c *C) {
 		{"select /*+ ", "select "},
 		{"select * from 🥳", "select * from"},
 		{"select 1 / 2", "select ? / ?"},
+		{"select * from t where a = 40 limit ?, ?", "select * from t where a = ? limit ..."},
+		{"select * from t where a > ?", "select * from t where a > ?"},
 	}
 	for _, test := range tests {
 		normalized := parser.Normalize(test.input)


### PR DESCRIPTION
cherry-pick #1040 to release-4.0

---
### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/pingcap/tidb/issues/19836

Currently, `normalize()` doesn't handle `paramMarker`('?'), this makes some bindings can't work as expected like the issue above.

Prepared statement `select * from t limit ?, ?` is normalized to `select * from t limit ?, ?`. However, a binding for `select * from t limit 1, 2` is normalized to and can only be matched by `select * from t limit ...`.

### What is changed and how it works?

When normalizing SQL, consider `paramMarker` as literal, this will make `paramMarker` be normalized to `genericSymbol`. This makes sense also because both `paramMarker` and `genericSymbol` correspond to '?'.

After this change, `select * from t limit ?, ?` will be normalized to `select * from t limit ...` instead of `select * from t limit ?, ?`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
