### PR TITLE
types: fix incorrect `show create table` when the flen is 0 for char and varchar

### DIFF
--- a/types/field_type.go
+++ b/types/field_type.go
@@ -136,10 +136,10 @@ func (ft *FieldType) CompactStr() string {
 
 	// displayFlen and displayDecimal are flen and decimal values with `-1` substituted with default value.
 	displayFlen, displayDecimal := ft.Flen, ft.Decimal
-	if displayFlen == 0 || displayFlen == UnspecifiedLength {
+	if displayFlen == UnspecifiedLength {
 		displayFlen = defaultFlen
 	}
-	if displayDecimal == 0 || displayDecimal == UnspecifiedLength {
+	if displayDecimal == UnspecifiedLength {
 		displayDecimal = defaultDecimal
 	}
 

--- a/types/field_type_test.go
+++ b/types/field_type_test.go
@@ -191,6 +191,18 @@ func (s *testFieldTypeSuite) TestFieldType(c *C) {
 	ft.Decimal = 2
 	c.Assert(ft.String(), Equals, "year(2)") // Note: Invalid year.
 	c.Assert(HasCharset(ft), IsFalse)
+
+	ft = NewFieldType(mysql.TypeVarchar)
+	ft.Flen = 0
+	ft.Decimal = 0
+	c.Assert(ft.String(), Equals, "varchar(0)")
+	c.Assert(HasCharset(ft), IsTrue)
+
+	ft = NewFieldType(mysql.TypeString)
+	ft.Flen = 0
+	ft.Decimal = 0
+	c.Assert(ft.String(), Equals, "char(0)")
+	c.Assert(HasCharset(ft), IsTrue)
 }
 
 func (s *testFieldTypeSuite) TestHasCharsetFromStmt(c *C) {


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close https://github.com/pingcap/tidb/issues/17332

### What is changed and how it works?
If displayFlen is 0, don't use the default value.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes


Side effects



Related changes


