### PR TITLE
*: support multiple select options

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -984,6 +984,10 @@ func (n *SelectStmt) Restore(ctx *format.RestoreCtx) error {
 			ctx.WriteKeyWord("SQL_NO_CACHE ")
 		}
 
+		if n.SelectStmtOpts.CalcFoundRows {
+			ctx.WriteKeyWord("SQL_CALC_FOUND_ROWS ")
+		}
+
 		if n.TableHints != nil && len(n.TableHints) != 0 {
 			ctx.WritePlain("/*+ ")
 			for i, tableHint := range n.TableHints {
@@ -999,6 +1003,8 @@ func (n *SelectStmt) Restore(ctx *format.RestoreCtx) error {
 
 		if n.Distinct {
 			ctx.WriteKeyWord("DISTINCT ")
+		} else if n.SelectStmtOpts.ExplicitAll {
+			ctx.WriteKeyWord("ALL ")
 		}
 		if n.SelectStmtOpts.StraightJoin {
 			ctx.WriteKeyWord("STRAIGHT_JOIN ")

--- a/ast/misc.go
+++ b/ast/misc.go
@@ -2680,6 +2680,7 @@ type SelectStmtOpts struct {
 	StraightJoin    bool
 	Priority        mysql.PriorityEnum
 	TableHints      []*TableOptimizerHint
+	ExplicitAll     bool
 }
 
 // TableOptimizerHint is Table level optimizer hint

--- a/parser.y
+++ b/parser.y
@@ -8342,7 +8342,8 @@ SelectStmtOptsList:
 		opt := $2.(*ast.SelectStmtOpts)
 
 		// Merge options.
-		if opt.TableHints != nil {
+		// Always use the first hint.
+		if opt.TableHints != nil && opts.TableHints == nil {
 			opts.TableHints = opt.TableHints
 		}
 		if opt.Distinct {

--- a/parser.y
+++ b/parser.y
@@ -1055,12 +1055,7 @@ import (
 	RowValue                               "Row value"
 	RowStmt                                "Row constructor"
 	SelectLockOpt                          "FOR UPDATE or LOCK IN SHARE MODE,"
-	SelectStmtCalcFoundRows                "SELECT statement optional SQL_CALC_FOUND_ROWS"
-	SelectStmtSQLBigResult                 "SELECT statement optional SQL_BIG_RESULT"
-	SelectStmtSQLBufferResult              "SELECT statement optional SQL_BUFFER_RESULT"
 	SelectStmtSQLCache                     "SELECT statement optional SQL_CAHCE/SQL_NO_CACHE"
-	SelectStmtSQLSmallResult               "SELECT statement optional SQL_SMALL_RESULT"
-	SelectStmtStraightJoin                 "SELECT statement optional STRAIGHT_JOIN"
 	SelectStmtFieldList                    "SELECT statement field list"
 	SelectStmtLimit                        "SELECT statement LIMIT clause"
 	SelectStmtLimitOpt                     "SELECT statement optional LIMIT clause"
@@ -8286,25 +8281,25 @@ SelectStmtOpt:
 		opt.Priority = $1.(mysql.PriorityEnum)
 		$$ = opt
 	}
-|	SelectStmtSQLSmallResult
+|	"SQL_SMALL_RESULT"
 	{
 		opt := &ast.SelectStmtOpts{}
 		opt.SQLCache = true
-		opt.SQLSmallResult = $1.(bool)
+		opt.SQLSmallResult = true
 		$$ = opt
 	}
-|	SelectStmtSQLBigResult
+|	"SQL_BIG_RESULT"
 	{
 		opt := &ast.SelectStmtOpts{}
 		opt.SQLCache = true
-		opt.SQLBigResult = $1.(bool)
+		opt.SQLBigResult = true
 		$$ = opt
 	}
-|	SelectStmtSQLBufferResult
+|	"SQL_BUFFER_RESULT"
 	{
 		opt := &ast.SelectStmtOpts{}
 		opt.SQLCache = true
-		opt.SQLBufferResult = $1.(bool)
+		opt.SQLBufferResult = true
 		$$ = opt
 	}
 |	SelectStmtSQLCache
@@ -8313,18 +8308,18 @@ SelectStmtOpt:
 		opt.SQLCache = $1.(bool)
 		$$ = opt
 	}
-|	SelectStmtCalcFoundRows
+|	"SQL_CALC_FOUND_ROWS"
 	{
 		opt := &ast.SelectStmtOpts{}
 		opt.SQLCache = true
-		opt.CalcFoundRows = $1.(bool)
+		opt.CalcFoundRows = true
 		$$ = opt
 	}
-|	SelectStmtStraightJoin
+|	"STRAIGHT_JOIN"
 	{
 		opt := &ast.SelectStmtOpts{}
 		opt.SQLCache = true
-		opt.StraightJoin = $1.(bool)
+		opt.StraightJoin = true
 		$$ = opt
 	}
 
@@ -8403,24 +8398,6 @@ TableOptimizerHintsOpt:
 	}
 |	TableOptimizerHints
 
-SelectStmtCalcFoundRows:
-	"SQL_CALC_FOUND_ROWS"
-	{
-		$$ = true
-	}
-
-SelectStmtSQLBigResult:
-	"SQL_BIG_RESULT"
-	{
-		$$ = true
-	}
-
-SelectStmtSQLBufferResult:
-	"SQL_BUFFER_RESULT"
-	{
-		$$ = true
-	}
-
 SelectStmtSQLCache:
 	"SQL_CACHE"
 	{
@@ -8429,18 +8406,6 @@ SelectStmtSQLCache:
 |	"SQL_NO_CACHE"
 	{
 		$$ = false
-	}
-
-SelectStmtSQLSmallResult:
-	"SQL_SMALL_RESULT"
-	{
-		$$ = true
-	}
-
-SelectStmtStraightJoin:
-	"STRAIGHT_JOIN"
-	{
-		$$ = true
 	}
 
 SelectStmtFieldList:

--- a/parser_test.go
+++ b/parser_test.go
@@ -100,7 +100,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"max_rows", "min_rows", "national", "quarter", "escape", "grants", "status", "fields", "triggers", "language",
 		"delay_key_write", "isolation", "partitions", "repeatable", "committed", "uncommitted", "only", "serializable", "level",
 		"curtime", "variables", "dayname", "version", "btree", "hash", "row_format", "dynamic", "fixed", "compressed",
-		"compact", "redundant", "`sql_no_cache`", "`sql_cache`", "action", "round",
+		"compact", "redundant", "1 sql_no_cache", "1 sql_cache", "action", "round",
 		"enable", "disable", "reverse", "space", "privileges", "get_lock", "release_lock", "sleep", "no", "greatest", "least",
 		"binlog", "hex", "unhex", "function", "indexes", "from_unixtime", "processlist", "events", "less", "than", "timediff",
 		"ln", "log", "log2", "log10", "timestampdiff", "pi", "quote", "none", "super", "shared", "exclusive",

--- a/parser_test.go
+++ b/parser_test.go
@@ -100,7 +100,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"max_rows", "min_rows", "national", "quarter", "escape", "grants", "status", "fields", "triggers", "language",
 		"delay_key_write", "isolation", "partitions", "repeatable", "committed", "uncommitted", "only", "serializable", "level",
 		"curtime", "variables", "dayname", "version", "btree", "hash", "row_format", "dynamic", "fixed", "compressed",
-		"compact", "redundant", "sql_no_cache sql_no_cache", "sql_cache sql_cache", "action", "round",
+		"compact", "redundant", "`sql_no_cache`", "`sql_cache`", "action", "round",
 		"enable", "disable", "reverse", "space", "privileges", "get_lock", "release_lock", "sleep", "no", "greatest", "least",
 		"binlog", "hex", "unhex", "function", "indexes", "from_unixtime", "processlist", "events", "less", "than", "timediff",
 		"ln", "log", "log2", "log10", "timestampdiff", "pi", "quote", "none", "super", "shared", "exclusive",
@@ -445,7 +445,7 @@ func (s *testParserSuite) TestDMLStmt(c *C) {
 		{"SELECT DISTINCTS * FROM t", false, ""},
 		{"SELECT DISTINCT * FROM t", true, "SELECT DISTINCT * FROM `t`"},
 		{"SELECT DISTINCTROW * FROM t", true, "SELECT DISTINCT * FROM `t`"},
-		{"SELECT ALL * FROM t", true, "SELECT * FROM `t`"},
+		{"SELECT ALL * FROM t", true, "SELECT ALL * FROM `t`"},
 		{"SELECT DISTINCT ALL * FROM t", false, ""},
 		{"SELECT DISTINCTROW ALL * FROM t", false, ""},
 		{"INSERT INTO foo (a) VALUES (42)", true, "INSERT INTO `foo` (`a`) VALUES (42)"},
@@ -4206,6 +4206,8 @@ func (s *testParserSuite) TestSQLResult(c *C) {
 		{`select SQL_SMALL_RESULT c1 from t group by c1`, true, "SELECT SQL_SMALL_RESULT `c1` FROM `t` GROUP BY `c1`"},
 		{`select SQL_BUFFER_RESULT * from t`, true, "SELECT SQL_BUFFER_RESULT * FROM `t`"},
 		{`select sql_small_result sql_big_result sql_buffer_result 1`, true, "SELECT SQL_SMALL_RESULT SQL_BIG_RESULT SQL_BUFFER_RESULT 1"},
+		{`select STRAIGHT_JOIN SQL_SMALL_RESULT * from t`, true, "SELECT SQL_SMALL_RESULT STRAIGHT_JOIN * FROM `t`"},
+		{`select SQL_CALC_FOUND_ROWS DISTINCT * from t`, true, "SELECT SQL_CALC_FOUND_ROWS DISTINCT * FROM `t`"},
 	}
 	s.RunTest(c, table)
 }

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -53,6 +53,8 @@ var (
 	ErrWarnDeprecatedSyntaxNoReplacement = terror.ClassParser.NewStd(mysql.ErrWarnDeprecatedSyntaxNoReplacement)
 	// ErrWarnDeprecatedIntegerDisplayWidth share the same code 1681, and it will be returned when length is specified in integer.
 	ErrWarnDeprecatedIntegerDisplayWidth = terror.ClassParser.NewStdErr(mysql.ErrWarnDeprecatedSyntaxNoReplacement, mysql.Message("Integer display width is deprecated and will be removed in a future release.", nil))
+	// ErrWrongUsage returns for incorrect usages.
+	ErrWrongUsage = terror.ClassParser.NewStd(mysql.ErrWrongUsage)
 	// SpecFieldPattern special result field pattern
 	SpecFieldPattern = regexp.MustCompile(`(\/\*!(M?[0-9]{5,6})?|\*\/)`)
 	specCodeStart    = regexp.MustCompile(`^\/\*!(M?[0-9]{5,6})?[ \t]*`)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close issue https://github.com/pingcap/tidb/issues/20133

### What is changed and how it works?
Add SelectStmtOptsList, and merge options if there is more than one option.

Note: After this PR merge.
`select SQL_BUFFER_RESULT SQL_BUFFER_RESULT  from t;` would cause parser error. This is the same as MySQL.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects

 - Breaking backward compatibility

Related changes


