### PR TITLE
ast: fix restore panic for TRIM() when arguments contain column name (#1124)

### DIFF
--- a/ast/functions.go
+++ b/ast/functions.go
@@ -415,7 +415,7 @@ func (n *FuncCallExpr) Restore(ctx *format.RestoreCtx) error {
 			ctx.WritePlain(" ")
 			fallthrough
 		case 2:
-			if n.Args[1].(ValueExpr).GetValue() != nil {
+			if expr, isValue := n.Args[1].(ValueExpr); !isValue || expr.GetValue() != nil {
 				if err := n.Args[1].Restore(ctx); err != nil {
 					return errors.Annotatef(err, "An error occurred while restore FuncCallExpr.Args[1]")
 				}

--- a/ast/functions_test.go
+++ b/ast/functions_test.go
@@ -65,6 +65,7 @@ func (ts *testFunctionsSuite) TestFuncCallExprRestore(c *C) {
 		{"TRIM(LEADING 'x' FROM 'xxxyxxx')", "TRIM(LEADING 'x' FROM 'xxxyxxx')"},
 		{"TRIM(BOTH 'x' FROM 'xxxyxxx')", "TRIM(BOTH 'x' FROM 'xxxyxxx')"},
 		{"TRIM(TRAILING 'x' FROM 'xxxyxxx')", "TRIM(TRAILING 'x' FROM 'xxxyxxx')"},
+		{"TRIM(BOTH col1 FROM col2)", "TRIM(BOTH `col1` FROM `col2`)"},
 		{"DATE_ADD('2008-01-02', INTERVAL INTERVAL(1, 0, 1) DAY)", "DATE_ADD('2008-01-02', INTERVAL INTERVAL(1, 0, 1) DAY)"},
 		{"BENCHMARK(1000000, AES_ENCRYPT('text', UNHEX('F3229A0B371ED2D9441B830D21A390C3')))", "BENCHMARK(1000000, AES_ENCRYPT('text', UNHEX('F3229A0B371ED2D9441B830D21A390C3')))"},
 		{"SUBSTRING('Quadratically', 5)", "SUBSTRING('Quadratically', 5)"},


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/parser/pull/1124