### PR TITLE
digester: keep the singleAtIdentifier in normalize

### DIFF
--- a/digester.go
+++ b/digester.go
@@ -163,6 +163,9 @@ func (d *sqlDigester) normalize(sql string) {
 	}
 	d.lexer.reset("")
 	for i, token := range d.tokens {
+		if token.tok == singleAtIdentifier {
+			d.buffer.WriteString("@")
+		}
 		d.buffer.WriteString(token.lit)
 		if i != len(d.tokens)-1 {
 			d.buffer.WriteRune(' ')

--- a/digester_test.go
+++ b/digester_test.go
@@ -54,6 +54,7 @@ func (s *testSQLDigestSuite) TestNormalize(c *C) {
 		{"select 1 / 2", "select ? / ?"},
 		{"select * from t where a = 40 limit ?, ?", "select * from t where a = ? limit ..."},
 		{"select * from t where a > ?", "select * from t where a > ?"},
+		{"select @a=b from t", "select @a = b from t"},
 	}
 	for _, test := range tests {
 		normalized := parser.Normalize(test.input)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/21820

### What is changed and how it works?

Keep the `@` when normalizing a query.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

N/A

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
