### PR TITLE
lexer: treat dot differently in different context

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -71,6 +71,7 @@ type Scanner struct {
 	// hintPos records the start position of the previous optimizer hint.
 	lastHintPos Pos
 
+	// true if a dot follows an identifier
 	identifierDot bool
 }
 

--- a/lexer.go
+++ b/lexer.go
@@ -70,6 +70,8 @@ type Scanner struct {
 
 	// hintPos records the start position of the previous optimizer hint.
 	lastHintPos Pos
+
+	identifierDot bool
 }
 
 // Errors returns the errors and warns during a scan.
@@ -488,6 +490,7 @@ func scanIdentifier(s *Scanner) (int, Pos, string) {
 	pos := s.r.pos()
 	s.r.inc()
 	s.r.incAsLongAs(isIdentChar)
+	s.identifierDot = s.r.peek() == '.'
 	return identifier, pos, s.r.data(&pos)
 }
 
@@ -638,6 +641,9 @@ func handleEscape(s *Scanner) rune {
 }
 
 func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
+	if s.identifierDot {
+		return scanIdentifier(s)
+	}
 	pos = s.r.pos()
 	tok = intLit
 	ch0 := s.r.readByte()
@@ -696,14 +702,15 @@ func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
 func startWithDot(s *Scanner) (tok int, pos Pos, lit string) {
 	pos = s.r.pos()
 	s.r.inc()
-	save := s.r.pos()
+	if s.identifierDot {
+		return int('.'), pos, "."
+	}
 	if isDigit(s.r.peek()) {
-		tok, _, lit = s.scanFloat(&pos)
-		if s.r.eof() || !isIdentChar(s.r.peek()) {
-			return
+		tok, p, l := s.scanFloat(&pos)
+		if tok == identifier {
+			return invalid, p, l
 		}
-		// Fail to parse a float, reset to dot.
-		s.r.p = save
+		return tok, p, l
 	}
 	tok, lit = int('.'), "."
 	return
@@ -742,14 +749,17 @@ func (s *Scanner) scanFloat(beg *Pos) (tok int, pos Pos, lit string) {
 	if ch0 == 'e' || ch0 == 'E' {
 		s.r.inc()
 		ch0 = s.r.peek()
-		if ch0 == '-' || ch0 == '+' || isDigit(ch0) {
+		if ch0 == '-' || ch0 == '+' {
 			s.r.inc()
+		}
+		if isDigit(s.r.peek()) {
 			s.scanDigits()
 			tok = floatLit
 		} else {
 			// D1 . D2 e XX when XX is not D3, parse the result to an identifier.
 			// 9e9e = 9e9(float) + e(identifier)
 			// 9est = 9est(identifier)
+			s.r.p = *beg
 			s.r.incAsLongAs(isIdentChar)
 			tok = identifier
 		}

--- a/lexer.go
+++ b/lexer.go
@@ -446,6 +446,7 @@ func startWithStar(s *Scanner) (tok int, pos Pos, lit string) {
 		return s.scan()
 	}
 	// otherwise it is just a normal star.
+	s.identifierDot = false
 	return '*', pos, "*"
 }
 

--- a/lexer.go
+++ b/lexer.go
@@ -274,9 +274,8 @@ func startWithXx(s *Scanner) (tok int, pos Pos, lit string) {
 		}
 		return
 	}
-	s.r.incAsLongAs(isIdentChar)
-	tok, lit = identifier, s.r.data(&pos)
-	return
+	s.r.p = pos
+	return scanIdentifier(s)
 }
 
 func startWithNn(s *Scanner) (tok int, pos Pos, lit string) {
@@ -307,9 +306,8 @@ func startWithBb(s *Scanner) (tok int, pos Pos, lit string) {
 		}
 		return
 	}
-	s.r.incAsLongAs(isIdentChar)
-	tok, lit = identifier, s.r.data(&pos)
-	return
+	s.r.p = pos
+	return scanIdentifier(s)
 }
 
 func startWithSharp(s *Scanner) (tok int, pos Pos, lit string) {
@@ -489,7 +487,6 @@ func startWithAt(s *Scanner) (tok int, pos Pos, lit string) {
 
 func scanIdentifier(s *Scanner) (int, Pos, string) {
 	pos := s.r.pos()
-	s.r.inc()
 	s.r.incAsLongAs(isIdentChar)
 	s.identifierDot = s.r.peek() == '.'
 	return identifier, pos, s.r.data(&pos)

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -125,23 +125,23 @@ func (s *testLexerSuite) TestLiteral(c *C) {
 		{"N'some text'", underscoreCS},
 		{"n'some text'", underscoreCS},
 		{"\\N", null},
-		{".*", int('.')},       // `.`, `*`
+		{".*", int('.')},     // `.`, `*`
 		{".1_t_1_x", decLit}, // `.1`, `_t_1_x`
-		{"9e9e", floatLit},     // 9e9e = 9e9 + e
+		{"9e9e", floatLit},   // 9e9e = 9e9 + e
 		{".1e", invalid},
 		// Issue #3954
-		{".1e23", floatLit}, // `.1e23`
-		{".123", decLit},    // `.123`
-		{".1*23", decLit},   // `.1`, `*`, `23`
-		{".1,23", decLit},   // `.1`, `,`, `23`
-		{".1 23", decLit},   // `.1`, `23`
-		{".1$23", decLit},    // `.1`, `$23`
-		{".1a23", decLit},    // `.1`, `a23`
+		{".1e23", floatLit},    // `.1e23`
+		{".123", decLit},       // `.123`
+		{".1*23", decLit},      // `.1`, `*`, `23`
+		{".1,23", decLit},      // `.1`, `,`, `23`
+		{".1 23", decLit},      // `.1`, `23`
+		{".1$23", decLit},      // `.1`, `$23`
+		{".1a23", decLit},      // `.1`, `a23`
 		{".1e23$23", floatLit}, // `.1e23`, `$23`
 		{".1e23a23", floatLit}, // `.1e23`, `a23`
-		{".1C23", decLit},    // `.1`, `C23`
-		{".1\u0081", decLit}, // `.1`, `\u0081`
-		{".1\uff34", decLit}, // `.1`, `\uff34`
+		{".1C23", decLit},      // `.1`, `C23`
+		{".1\u0081", decLit},   // `.1`, `\u0081`
+		{".1\uff34", decLit},   // `.1`, `\uff34`
 		{`b''`, bitLit},
 		{`b'0101'`, bitLit},
 		{`0b0101`, bitLit},

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -126,22 +126,22 @@ func (s *testLexerSuite) TestLiteral(c *C) {
 		{"n'some text'", underscoreCS},
 		{"\\N", null},
 		{".*", int('.')},       // `.`, `*`
-		{".1_t_1_x", int('.')}, // `.`, `1_t_1_x`
+		{".1_t_1_x", decLit}, // `.1`, `_t_1_x`
 		{"9e9e", floatLit},     // 9e9e = 9e9 + e
+		{".1e", invalid},
 		// Issue #3954
 		{".1e23", floatLit}, // `.1e23`
 		{".123", decLit},    // `.123`
 		{".1*23", decLit},   // `.1`, `*`, `23`
 		{".1,23", decLit},   // `.1`, `,`, `23`
 		{".1 23", decLit},   // `.1`, `23`
-		// TODO: See #3963. The following test cases do not test the ambiguity.
-		{".1$23", int('.')},    // `.`, `1$23`
-		{".1a23", int('.')},    // `.`, `1a23`
-		{".1e23$23", int('.')}, // `.`, `1e23$23`
-		{".1e23a23", int('.')}, // `.`, `1e23a23`
-		{".1C23", int('.')},    // `.`, `1C23`
-		{".1\u0081", int('.')}, // `.`, `1\u0081`
-		{".1\uff34", int('.')}, // `.`, `1\uff34`
+		{".1$23", decLit},    // `.1`, `$23`
+		{".1a23", decLit},    // `.1`, `a23`
+		{".1e23$23", floatLit}, // `.1e23`, `$23`
+		{".1e23a23", floatLit}, // `.1e23`, `a23`
+		{".1C23", decLit},    // `.1`, `C23`
+		{".1\u0081", decLit}, // `.1`, `\u0081`
+		{".1\uff34", decLit}, // `.1`, `\uff34`
 		{`b''`, bitLit},
 		{`b'0101'`, bitLit},
 		{`0b0101`, bitLit},

--- a/parser_test.go
+++ b/parser_test.go
@@ -263,6 +263,17 @@ func (s *testParserSuite) TestSimple(c *C) {
 	expr = sel.Fields.Fields[0]
 	vExpr = expr.Expr.(*test_driver.ValueExpr)
 	c.Assert(vExpr.Kind(), Equals, test_driver.KindUint64)
+
+	src = `select 99e+r10 from t1;`
+	st, err = parser.ParseOneStmt(src, "", "")
+	c.Assert(err, IsNil)
+	sel, ok = st.(*ast.SelectStmt)
+	c.Assert(ok, IsTrue)
+	bExpr, ok := sel.Fields.Fields[0].Expr.(*ast.BinaryOperationExpr)
+	c.Assert(ok, IsTrue)
+	c.Assert(bExpr.Op, Equals, opcode.Plus)
+	c.Assert(bExpr.L.(*ast.ColumnNameExpr).Name.Name.O, Equals, "99e")
+	c.Assert(bExpr.R.(*ast.ColumnNameExpr).Name.Name.O, Equals, "r10")
 }
 
 func (s *testParserSuite) TestSpecialComments(c *C) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -284,6 +284,18 @@ func (s *testParserSuite) TestSimple(c *C) {
 	varExpr, ok := sel.Fields.Fields[1].Expr.(*ast.VariableExpr)
 	c.Assert(ok, IsTrue)
 	c.Assert(varExpr.Name, Equals, "c3")
+
+	src = `select t.1e from test.t;`
+	st, err = parser.ParseOneStmt(src, "", "")
+	c.Assert(err, IsNil)
+	sel, ok = st.(*ast.SelectStmt)
+	c.Assert(ok, IsTrue)
+	colExpr, ok := sel.Fields.Fields[0].Expr.(*ast.ColumnNameExpr)
+	c.Assert(colExpr.Name.Table.O, Equals, "t")
+	c.Assert(colExpr.Name.Name.O, Equals, "1e")
+	tName := sel.From.TableRefs.Left.(*ast.TableSource).Source.(*ast.TableName)
+	c.Assert(tName.Schema.O, Equals, "test")
+	c.Assert(tName.Name.O, Equals, "t")
 }
 
 func (s *testParserSuite) TestSpecialComments(c *C) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -274,6 +274,16 @@ func (s *testParserSuite) TestSimple(c *C) {
 	c.Assert(bExpr.Op, Equals, opcode.Plus)
 	c.Assert(bExpr.L.(*ast.ColumnNameExpr).Name.Name.O, Equals, "99e")
 	c.Assert(bExpr.R.(*ast.ColumnNameExpr).Name.Name.O, Equals, "r10")
+
+	src = `select t./*123*/*,@c3:=0 from t order by t.c1;`
+	st, err = parser.ParseOneStmt(src, "", "")
+	c.Assert(err, IsNil)
+	sel, ok = st.(*ast.SelectStmt)
+	c.Assert(ok, IsTrue)
+	c.Assert(sel.Fields.Fields[0].WildCard.Table.O, Equals, "t")
+	varExpr, ok := sel.Fields.Fields[1].Expr.(*ast.VariableExpr)
+	c.Assert(ok, IsTrue)
+	c.Assert(varExpr.Name, Equals, "c3")
 }
 
 func (s *testParserSuite) TestSpecialComments(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close https://github.com/pingcap/parser/issues/1114

related tidb issues: 
https://github.com/pingcap/tidb/issues/3963
https://github.com/pingcap/tidb/issues/21677

### What is changed and how it works?

`dot` after the identifier is token '.'
start with `dot` should be numbers

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
