### PR TITLE
Add CannotInsertFlag to indicate that this table cannot be inserted

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -326,6 +326,9 @@ type TableInfo struct {
 	// IsColumnar means the table is column-oriented.
 	// It's true when the engine of the table is TiFlash only.
 	IsColumnar bool `json:"is_columnar"`
+
+	// Can't insert when table 'add column date/datetime not null' during ddl in NO_ZERO_DATE.
+	CannotInsertFlag bool `can_not_insert_flag`
 }
 
 // TableLockInfo provides meta data describing a table lock.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Include `no_zero_date` in `sqlmode`, these scenarios should fail to `add column`:
```
create table t (id int);
insert into t values(1);
alter table t add column a date not null;
alter table t add column a date not null;
```
Considering that data may be written during the DDL state change phase, need a flag to prevent data insert during this period. So add this flag.

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has exported variable/fields change

Side effects

Related changes
