### PR TITLE
parser: remove invalid syntax

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -6118,13 +6118,6 @@ SimpleIdent:
 			Name:  model.NewCIStr($3),
 		}}
 	}
-|	'.' Identifier '.' Identifier
-	{
-		$$ = &ast.ColumnNameExpr{Name: &ast.ColumnName{
-			Table: model.NewCIStr($2),
-			Name:  model.NewCIStr($4),
-		}}
-	}
 |	Identifier '.' Identifier '.' Identifier
 	{
 		$$ = &ast.ColumnNameExpr{Name: &ast.ColumnName{

--- a/parser_test.go
+++ b/parser_test.go
@@ -1312,7 +1312,7 @@ func (s *testParserSuite) TestExpression(c *C) {
 		{"select {ts123 '1989-09-10 11:11:11'}", true, "SELECT _UTF8MB4'1989-09-10 11:11:11'"},
 		{"select {ts123 123}", true, "SELECT 123"},
 		{"select {ts123 1 xor 1}", true, "SELECT 1 XOR 1"},
-		{"select .t.a", false, ""},
+		{"select .t.a from t", false, ""},
 	}
 	s.RunTest(c, table)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -1312,6 +1312,7 @@ func (s *testParserSuite) TestExpression(c *C) {
 		{"select {ts123 '1989-09-10 11:11:11'}", true, "SELECT _UTF8MB4'1989-09-10 11:11:11'"},
 		{"select {ts123 123}", true, "SELECT 123"},
 		{"select {ts123 1 xor 1}", true, "SELECT 1 XOR 1"},
+		{"select .t.a", false, ""},
 	}
 	s.RunTest(c, table)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

syntax like `select .t.a from t` is invalid in MySQL. remove it
