### PR TITLE
misc: move keyword 'ROW' from 'tokenMap' to 'windowFuncTokenMap'

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -577,7 +577,6 @@ var tokenMap = map[string]int{
 	"ROUTINE":                  routine,
 	"ROW_COUNT":                rowCount,
 	"ROW_FORMAT":               rowFormat,
-	"ROW":                      row,
 	"ROWS":                     rows,
 	"RTREE":                    rtree,
 	"RESUME":                   resume,
@@ -812,6 +811,7 @@ var windowFuncTokenMap = map[string]int{
 	"OVER":         over,
 	"PERCENT_RANK": percentRank,
 	"RANK":         rank,
+	"ROW":          row,
 	"ROW_NUMBER":   rowNumber,
 	"WINDOW":       window,
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -927,6 +927,11 @@ AAAAAAAAAAAA5gm5Mg==
 		{"CREATE SEQUENCE seq INCREMENT -9223372036854775808", true, "CREATE SEQUENCE `seq` INCREMENT BY -9223372036854775808"},
 		{"CREATE SEQUENCE seq INCREMENT -9223372036854775809", false, ""},
 	}
+	original := s.enableWindowFunc
+	defer func() {
+		s.enableWindowFunc = original
+	}()
+	s.enableWindowFunc = true
 	s.RunTest(c, table)
 }
 
@@ -1996,6 +2001,11 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"select next value for sequence", true, "SELECT NEXTVAL(`sequence`)"},
 		{"select NeXt vAluE for seQuEncE2", true, "SELECT NEXTVAL(`seQuEncE2`)"},
 	}
+	original := s.enableWindowFunc
+	defer func() {
+		s.enableWindowFunc = original
+	}()
+	s.enableWindowFunc = true
 	s.RunTest(c, table)
 
 	// Test in REAL_AS_FLOAT SQL mode.
@@ -2065,6 +2075,11 @@ func (s *testParserSuite) TestIdentifier(c *C) {
 		{"select .78`123`", true, "SELECT 0.78 AS `123`"},
 		{`select .78"123"`, true, "SELECT 0.78 AS `123`"},
 	}
+	original := s.enableWindowFunc
+	defer func() {
+		s.enableWindowFunc = original
+	}()
+	s.enableWindowFunc = true
 	s.RunTest(c, table)
 }
 
@@ -4062,6 +4077,11 @@ func (s *testParserSuite) TestSetOperator(c *C) {
 		{"((select c1 from t1) except select c2 from t2) intersect all (select c3 from t3) order by c1 limit 1", true, "((SELECT `c1` FROM `t1`) EXCEPT SELECT `c2` FROM `t2`) INTERSECT ALL (SELECT `c3` FROM `t3`) ORDER BY `c1` LIMIT 1"},
 		{"select 1 union distinct (select 1 except all select 1 intersect select 1)", true, "SELECT 1 UNION (SELECT 1 EXCEPT ALL SELECT 1 INTERSECT SELECT 1)"},
 	}
+	original := s.enableWindowFunc
+	defer func() {
+		s.enableWindowFunc = original
+	}()
+	s.enableWindowFunc = true
 	s.RunTest(c, table)
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Make it possible to use 'ROW' as unreserved keyword, which is useful for users to make migration from MySQL 5.7

### What is changed and how it works?
move keyword 'ROW' from 'tokenMap' to 'windowFuncTokenMap'.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported variable/fields change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
