### PR TITLE
*: create / drop extended stats by ALTER TABLE

### DIFF
--- a/ast/ddl_test.go
+++ b/ast/ddl_test.go
@@ -516,6 +516,14 @@ func (ts *testDDLSuite) TestAlterTableSpecRestore(c *C) {
 		{"coalesce partition 3", "COALESCE PARTITION 3"},
 		{"drop partition p1", "DROP PARTITION `p1`"},
 		{"TRUNCATE PARTITION p0", "TRUNCATE PARTITION `p0`"},
+		{"add tidb_stats s1 cardinality(a,b)", "ADD TIDB_STATS `s1` CARDINALITY(`a`, `b`)"},
+		{"add tidb_stats if not exists s1 cardinality(a,b)", "ADD TIDB_STATS IF NOT EXISTS `s1` CARDINALITY(`a`, `b`)"},
+		{"add tidb_stats s1 correlation(a,b)", "ADD TIDB_STATS `s1` CORRELATION(`a`, `b`)"},
+		{"add tidb_stats if not exists s1 correlation(a,b)", "ADD TIDB_STATS IF NOT EXISTS `s1` CORRELATION(`a`, `b`)"},
+		{"add tidb_stats s1 dependency(a,b)", "ADD TIDB_STATS `s1` DEPENDENCY(`a`, `b`)"},
+		{"add tidb_stats if not exists s1 dependency(a,b)", "ADD TIDB_STATS IF NOT EXISTS `s1` DEPENDENCY(`a`, `b`)"},
+		{"drop tidb_stats s1", "DROP TIDB_STATS `s1`"},
+		{"drop tidb_stats if exists s1", "DROP TIDB_STATS IF EXISTS `s1`"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*AlterTableStmt).Specs[0]

--- a/ast/misc.go
+++ b/ast/misc.go
@@ -1572,6 +1572,13 @@ const (
 	StatsTypeCorrelation
 )
 
+// StatisticsSpec is the specification for ADD /DROP STATISTICS.
+type StatisticsSpec struct {
+	StatsName string
+	StatsType uint8
+	Columns   []*ColumnName
+}
+
 // CreateStatisticsStmt is a statement to create extended statistics.
 // Examples:
 //   CREATE STATISTICS stats1 (cardinality) ON t(a, b, c);
@@ -1947,7 +1954,7 @@ func (n *AdminStmt) Restore(ctx *format.RestoreCtx) error {
 	case AdminResetTelemetryID:
 		ctx.WriteKeyWord("RESET TELEMETRY_ID")
 	case AdminReloadStatistics:
-		ctx.WriteKeyWord("RELOAD STATISTICS")
+		ctx.WriteKeyWord("RELOAD TIDB_STATS")
 	default:
 		return errors.New("Unsupported AdminStmt type")
 	}

--- a/misc.go
+++ b/misc.go
@@ -683,6 +683,7 @@ var tokenMap = map[string]int{
 	"THAN":                     than,
 	"THEN":                     then,
 	"TIDB":                     tidb,
+	"TIDB_STATS":               tidbStats,
 	"TIFLASH":                  tiFlash,
 	"TIKV_IMPORTER":            tikvImporter,
 	"TIME":                     timeType,

--- a/parser_test.go
+++ b/parser_test.go
@@ -790,7 +790,9 @@ func (s *testParserSuite) TestDMLStmt(c *C) {
 		{"admin reload bindings", true, "ADMIN RELOAD BINDINGS"},
 		{"admin show telemetry", true, "ADMIN SHOW TELEMETRY"},
 		{"admin reset telemetry_id", true, "ADMIN RESET TELEMETRY_ID"},
-		{"admin reload statistics", true, "ADMIN RELOAD STATISTICS"},
+		// This case would be removed once TiDB PR to remove ADMIN RELOAD STATISTICS is merged.
+		{"admin reload statistics", true, "ADMIN RELOAD TIDB_STATS"},
+		{"admin reload tidb_stats", true, "ADMIN RELOAD TIDB_STATS"},
 
 		// for on duplicate key update
 		{"INSERT INTO t (a,b,c) VALUES (1,2,3),(4,5,6) ON DUPLICATE KEY UPDATE c=VALUES(a)+VALUES(b);", true, "INSERT INTO `t` (`a`,`b`,`c`) VALUES (1,2,3),(4,5,6) ON DUPLICATE KEY UPDATE `c`=VALUES(`a`)+VALUES(`b`)"},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Change the extended statistics SQL interfaces according to https://docs.google.com/document/d/1rRIQ8ekoKJH8qeB-J15QRaycLys8_19GBnij7q_O7Vg/edit.

### What is changed and how it works?

Use `ALTER TABLE ... ADD / DROP STATISTICS` syntax for create / drop extended statistics. Old syntax in https://github.com/pingcap/parser/pull/913 would be removed later once the new syntax support is finished.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change
 - Has exported variable/fields change


Side effects

 - Breaking backward compatibility: the old syntax is not generally available now, so it should be fine to be removed.

Related changes

N/A
