### PR TITLE
yy_parser: enable supportWindowFunc by default (#986)

### DIFF
--- a/yy_parser.go
+++ b/yy_parser.go
@@ -93,9 +93,11 @@ func New() *Parser {
 		panic("no parser driver (forgotten import?) https://github.com/pingcap/parser/issues/43")
 	}
 
-	return &Parser{
+	p := &Parser{
 		cache: make([]yySymType, 200),
 	}
+	p.EnableWindowFunc(true)
+	return p
 }
 
 // Parse parses a query string to raw ast.StmtNode.


### PR DESCRIPTION
Cherry-pick #986 to release-4.0.

Close https://github.com/pingcap/tidb/issues/22151.