### PR TITLE
*: remove proxy from reserved keyword

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -212,7 +212,6 @@ import (
 	precisionType     "PRECISION"
 	primary           "PRIMARY"
 	procedure         "PROCEDURE"
-	proxy             "PROXY"
 	rangeKwd          "RANGE"
 	rank              "RANK"
 	read              "READ"
@@ -493,6 +492,7 @@ import (
 	processlist           "PROCESSLIST"
 	profile               "PROFILE"
 	profiles              "PROFILES"
+	proxy                 "PROXY"
 	purge                 "PURGE"
 	quarter               "QUARTER"
 	queries               "QUERIES"
@@ -5312,6 +5312,7 @@ UnReservedKeyword:
 |	"PASSWORD" %prec lowerThanEq
 |	"PREPARE"
 |	"PRE_SPLIT_REGIONS"
+|	"PROXY"
 |	"QUICK"
 |	"REBUILD"
 |	"REDUNDANT"

--- a/parser_test.go
+++ b/parser_test.go
@@ -103,7 +103,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"compact", "redundant", "1 sql_no_cache", "1 sql_cache", "action", "round",
 		"enable", "disable", "reverse", "space", "privileges", "get_lock", "release_lock", "sleep", "no", "greatest", "least",
 		"binlog", "hex", "unhex", "function", "indexes", "from_unixtime", "processlist", "events", "less", "than", "timediff",
-		"ln", "log", "log2", "log10", "timestampdiff", "pi", "quote", "none", "super", "shared", "exclusive",
+		"ln", "log", "log2", "log10", "timestampdiff", "pi", "proxy", "quote", "none", "super", "shared", "exclusive",
 		"always", "stats", "stats_meta", "stats_histogram", "stats_buckets", "stats_healthy", "tidb_version", "replication", "slave", "client",
 		"max_connections_per_hour", "max_queries_per_hour", "max_updates_per_hour", "max_user_connections", "event", "reload", "routine", "temporary",
 		"following", "preceding", "unbounded", "respect", "nulls", "current", "last", "against", "expansion",


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>


### What problem does this PR solve? <!--add issue link with summary if exists-->
Remove `PROXY` from reserved keyword mapping because in MySQL it's not a reserved keyword.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch
