### PR TITLE
parser: regard NULL as literal when normalizing query

### DIFF
--- a/digester.go
+++ b/digester.go
@@ -338,6 +338,8 @@ func (d *sqlDigester) isLit(t token) (beLit bool) {
 		beLit = true
 	} else if t.lit == "*" {
 		beLit = true
+	} else if tok == null || strings.ToLower(t.lit) == "null" {
+		beLit = true
 	}
 	return
 }

--- a/digester.go
+++ b/digester.go
@@ -338,7 +338,7 @@ func (d *sqlDigester) isLit(t token) (beLit bool) {
 		beLit = true
 	} else if t.lit == "*" {
 		beLit = true
-	} else if tok == null || strings.ToLower(t.lit) == "null" {
+	} else if tok == null || (tok == identifier && strings.ToLower(t.lit) == "null") {
 		beLit = true
 	}
 	return

--- a/digester_test.go
+++ b/digester_test.go
@@ -31,6 +31,7 @@ func (s *testSQLDigestSuite) TestNormalize(c *C) {
 		{"SELECT 1", "select ?"},
 		{"select null", "select ?"},
 		{"select \\N", "select ?"},
+		{"SELECT `null`", "select null"},
 		{"select * from b where id = 1", "select * from b where id = ?"},
 		{"select 1 from b where id in (1, 3, '3', 1, 2, 3, 4)", "select ? from b where id in ( ... )"},
 		{"select 1 from b where id in (1, a, 4)", "select ? from b where id in ( ? , a , ? )"},

--- a/digester_test.go
+++ b/digester_test.go
@@ -29,6 +29,8 @@ func (s *testSQLDigestSuite) TestNormalize(c *C) {
 		expect string
 	}{
 		{"SELECT 1", "select ?"},
+		{"select null", "select ?"},
+		{"select \\N", "select ?"},
 		{"select * from b where id = 1", "select * from b where id = ?"},
 		{"select 1 from b where id in (1, 3, '3', 1, 2, 3, 4)", "select ? from b where id in ( ... )"},
 		{"select 1 from b where id in (1, a, 4)", "select ? from b where id in ( ? , a , ? )"},

--- a/digester_test.go
+++ b/digester_test.go
@@ -32,7 +32,7 @@ func (s *testSQLDigestSuite) TestNormalize(c *C) {
 		{"SELECT 1", "select ?"},
 		{"select null", "select ?"},
 		{"select \\N", "select ?"},
-		{"SELECT `null`", "select null"},
+		{"SELECT `null`", "select `null`"},
 		{"select * from b where id = 1", "select * from `b` where `id` = ?"},
 		{"select 1 from b where id in (1, 3, '3', 1, 2, 3, 4)", "select ? from `b` where `id` in ( ... )"},
 		{"select 1 from b where id in (1, a, 4)", "select ? from `b` where `id` in ( ? , `a` , ? )"},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, `Normalize()` converts `SELECT NULL` to `select null`, while NULL is regarded as a literal in MySQL, as described in the [documentation](https://dev.mysql.com/doc/refman/8.0/en/literals.html). It seems natural that `SELECT NULL` would be converted to `select ?` from the consistency viewpoint.

A famous query normalization tool, [pt-fingerprint](https://www.percona.com/doc/percona-toolkit/LATEST/pt-fingerprint.html), for MySQL also treats NULL in that way.

```
$ pt-fingerprint --query "SELECT NULL"
select ?
```

### What is changed and how it works?

Let `isLit()` regards `NULL` and `\N` as a literal.

Note that checking if `tok == null` in `isLit()` is not enough because `scan()` recognize `\N` as `null` but `NULL` as `identifier`. We should also check if `strings.ToLower(t.lit) == "null"`. This seems not so strange, in my view, since `scan()` just roughly classifies tokens.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
