### PR TITLE
parser: update the broken link for Contribution Guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ found you are one of the users but not listed here:
 
 ## Contributing
 
-Contributions are welcomed and greatly appreciated. See [CONTRIBUTING.md](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) for details on submitting patches and the contribution workflow.
+Contributions are welcomed and greatly appreciated. See [Contribution Guide](https://github.com/pingcap/community/blob/master/contributors/README.md) for details on submitting patches and the contribution workflow.
 
 Here is how to [update parser for TiDB](https://github.com/pingcap/parser/blob/master/docs/update-parser-for-tidb.md).
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

CONTRIBUTING.md was moved and the link to it in README.md is broken.

Related PR: https://github.com/pingcap/tidb/pull/20964

### What is changed and how it works?

Just replace the broken link in README.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code