### PR TITLE
Changed ActionType def from hardcode to iota

### DIFF
--- a/model/ddl.go
+++ b/model/ddl.go
@@ -30,54 +30,54 @@ type ActionType byte
 
 // List DDL actions.
 const (
-	ActionNone                          ActionType = 0
-	ActionCreateSchema                  ActionType = 1
-	ActionDropSchema                    ActionType = 2
-	ActionCreateTable                   ActionType = 3
-	ActionDropTable                     ActionType = 4
-	ActionAddColumn                     ActionType = 5
-	ActionDropColumn                    ActionType = 6
-	ActionAddIndex                      ActionType = 7
-	ActionDropIndex                     ActionType = 8
-	ActionAddForeignKey                 ActionType = 9
-	ActionDropForeignKey                ActionType = 10
-	ActionTruncateTable                 ActionType = 11
-	ActionModifyColumn                  ActionType = 12
-	ActionRebaseAutoID                  ActionType = 13
-	ActionRenameTable                   ActionType = 14
-	ActionSetDefaultValue               ActionType = 15
-	ActionShardRowID                    ActionType = 16
-	ActionModifyTableComment            ActionType = 17
-	ActionRenameIndex                   ActionType = 18
-	ActionAddTablePartition             ActionType = 19
-	ActionDropTablePartition            ActionType = 20
-	ActionCreateView                    ActionType = 21
-	ActionModifyTableCharsetAndCollate  ActionType = 22
-	ActionTruncateTablePartition        ActionType = 23
-	ActionDropView                      ActionType = 24
-	ActionRecoverTable                  ActionType = 25
-	ActionModifySchemaCharsetAndCollate ActionType = 26
-	ActionLockTable                     ActionType = 27
-	ActionUnlockTable                   ActionType = 28
-	ActionRepairTable                   ActionType = 29
-	ActionSetTiFlashReplica             ActionType = 30
-	ActionUpdateTiFlashReplicaStatus    ActionType = 31
-	ActionAddPrimaryKey                 ActionType = 32
-	ActionDropPrimaryKey                ActionType = 33
-	ActionCreateSequence                ActionType = 34
-	ActionAlterSequence                 ActionType = 35
-	ActionDropSequence                  ActionType = 36
-	ActionAddColumns                    ActionType = 37
-	ActionDropColumns                   ActionType = 38
-	ActionModifyTableAutoIdCache        ActionType = 39
-	ActionRebaseAutoRandomBase          ActionType = 40
-	ActionAlterIndexVisibility          ActionType = 41
-	ActionExchangeTablePartition        ActionType = 42
-	ActionAddCheckConstraint            ActionType = 43
-	ActionDropCheckConstraint           ActionType = 44
-	ActionAlterCheckConstraint          ActionType = 45
-	ActionAlterTableAlterPartition      ActionType = 46
-	ActionRenameTables                  ActionType = 47
+	ActionNone ActionType = iota
+	ActionCreateSchema
+	ActionDropSchema
+	ActionCreateTable
+	ActionDropTable
+	ActionAddColumn
+	ActionDropColumn
+	ActionAddIndex
+	ActionDropIndex
+	ActionAddForeignKey
+	ActionDropForeignKey
+	ActionTruncateTable
+	ActionModifyColumn
+	ActionRebaseAutoID
+	ActionRenameTable
+	ActionSetDefaultValue
+	ActionShardRowID
+	ActionModifyTableComment
+	ActionRenameIndex
+	ActionAddTablePartition
+	ActionDropTablePartition
+	ActionCreateView
+	ActionModifyTableCharsetAndCollate
+	ActionTruncateTablePartition
+	ActionDropView
+	ActionRecoverTable
+	ActionModifySchemaCharsetAndCollate
+	ActionLockTable
+	ActionUnlockTable
+	ActionRepairTable
+	ActionSetTiFlashReplica
+	ActionUpdateTiFlashReplicaStatus
+	ActionAddPrimaryKey
+	ActionDropPrimaryKey
+	ActionCreateSequence
+	ActionAlterSequence
+	ActionDropSequence
+	ActionAddColumns
+	ActionDropColumns
+	ActionModifyTableAutoIdCache
+	ActionRebaseAutoRandomBase
+	ActionAlterIndexVisibility
+	ActionExchangeTablePartition
+	ActionAddCheckConstraint
+	ActionDropCheckConstraint
+	ActionAlterCheckConstraint
+	ActionAlterTableAlterPartition
+	ActionRenameTables
 )
 
 const (


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
N/A. I assume it's better to slightly change those definitions to match the way we define other enum constants.

### What is changed and how it works?
Changed the way to define DDL action const from hardcoding to iota.

```Go
// From
const (
	ActionNone         ActionType = 0
	ActionCreateSchema ActionType = 1
	ActionDropSchema   ActionType = 2
)

//To
const (
	ActionNone ActionType = iota
	ActionCreateSchema
	ActionDropSchema
)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- N/A

Side effects

- N/A

Related changes

- N/A
