### PR TITLE
statistics: add a new syntax to support dropping statistics of partitions

### DIFF
--- a/ast/stats.go
+++ b/ast/stats.go
@@ -174,7 +174,8 @@ func (n *AnalyzeTableStmt) Accept(v Visitor) (Node, bool) {
 type DropStatsStmt struct {
 	stmtNode
 
-	Table *TableName
+	Table          *TableName
+	PartitionNames []model.CIStr
 }
 
 // Restore implements Node interface.
@@ -184,6 +185,15 @@ func (n *DropStatsStmt) Restore(ctx *format.RestoreCtx) error {
 		return errors.Annotate(err, "An error occurred while add table")
 	}
 
+	if len(n.PartitionNames) != 0 {
+		ctx.WriteKeyWord(" PARTITION ")
+	}
+	for i, partition := range n.PartitionNames {
+		if i != 0 {
+			ctx.WritePlain(",")
+		}
+		ctx.WriteName(partition.O)
+	}
 	return nil
 }
 

--- a/parser.y
+++ b/parser.y
@@ -4239,6 +4239,13 @@ DropStatsStmt:
 	{
 		$$ = &ast.DropStatsStmt{Table: $3.(*ast.TableName)}
 	}
+|	"DROP" "STATS" TableName "PARTITION" PartitionNameList
+	{
+		$$ = &ast.DropStatsStmt{
+			Table:          $3.(*ast.TableName),
+			PartitionNames: $5.([]model.CIStr),
+		}
+	}
 
 RestrictOrCascadeOpt:
 	{}

--- a/parser_test.go
+++ b/parser_test.go
@@ -2304,6 +2304,9 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"drop view if exists xxx", true, "DROP VIEW IF EXISTS `xxx`"},
 		{"drop view if exists xxx, yyy", true, "DROP VIEW IF EXISTS `xxx`, `yyy`"},
 		{"drop stats t", true, "DROP STATS `t`"},
+		{"drop stats t partition p0", true, "DROP STATS `t` PARTITION `p0`"},
+		{"drop stats t partition p0, p1, p2", true, "DROP STATS `t` PARTITION `p0`,`p1`,`p2`"},
+		{"drop stats t partition global", true, "DROP STATS `t` PARTITION `global`"},
 		// for issue 974
 		{`CREATE TABLE address (
 		id bigint(20) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
statistics: add a new syntax to support dropping statistics of partitions

### What is changed and how it works?
statistics: add a new syntax to support dropping statistics of partitions

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test