### PR TITLE
statistics: introduce a new kind of syntax to drop global-stats

### DIFF
--- a/ast/stats.go
+++ b/ast/stats.go
@@ -176,6 +176,7 @@ type DropStatsStmt struct {
 
 	Table          *TableName
 	PartitionNames []model.CIStr
+	IsGlobalStats  bool
 }
 
 // Restore implements Node interface.
@@ -183,6 +184,11 @@ func (n *DropStatsStmt) Restore(ctx *format.RestoreCtx) error {
 	ctx.WriteKeyWord("DROP STATS ")
 	if err := n.Table.Restore(ctx); err != nil {
 		return errors.Annotate(err, "An error occurred while add table")
+	}
+
+	if n.IsGlobalStats {
+		ctx.WriteKeyWord(" GLOBAL")
+		return nil
 	}
 
 	if len(n.PartitionNames) != 0 {

--- a/parser.y
+++ b/parser.y
@@ -4246,6 +4246,13 @@ DropStatsStmt:
 			PartitionNames: $5.([]model.CIStr),
 		}
 	}
+|	"DROP" "STATS" TableName "GLOBAL"
+	{
+		$$ = &ast.DropStatsStmt{
+			Table:         $3.(*ast.TableName),
+			IsGlobalStats: true,
+		}
+	}
 
 RestrictOrCascadeOpt:
 	{}

--- a/parser_test.go
+++ b/parser_test.go
@@ -2309,7 +2309,7 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"drop stats t", true, "DROP STATS `t`"},
 		{"drop stats t partition p0", true, "DROP STATS `t` PARTITION `p0`"},
 		{"drop stats t partition p0, p1, p2", true, "DROP STATS `t` PARTITION `p0`,`p1`,`p2`"},
-		{"drop stats t partition global", true, "DROP STATS `t` PARTITION `global`"},
+		{"drop stats t global", true, "DROP STATS `t` GLOBAL"},
 		// for issue 974
 		{`CREATE TABLE address (
 		id bigint(20) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Before this PR, we already have the syntax `drop stats {table-name} partition {partition-name}` to drop partition-stats.
And if we want to drop global-stats, we now use the keyword `global` to replace `{partition-name}` like `drop stats t partition global`.
But this solution may cause a conflict if a user names a partition as `global`.
To solve this conflict, this PR introduces a new kind of syntax `drop stats {table-name} global`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test