### PR TITLE
set right not null flag when newing extra PK

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -577,7 +577,7 @@ func NewExtraHandleColInfo() *ColumnInfo {
 		ID:   ExtraHandleID,
 		Name: ExtraHandleName,
 	}
-	colInfo.Flag = mysql.PriKeyFlag
+	colInfo.Flag = mysql.PriKeyFlag | mysql.NotNullFlag
 	colInfo.Tp = mysql.TypeLonglong
 	colInfo.Flen, colInfo.Decimal = mysql.GetDefaultFieldLengthAndDecimal(mysql.TypeLonglong)
 	return colInfo

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -140,6 +140,9 @@ func (*testModelSuite) TestModelBasic(c *C) {
 	}
 	no := anIndex.HasPrefixIndex()
 	c.Assert(no, Equals, false)
+
+	extraPK := NewExtraHandleColInfo()
+	c.Assert(extraPK.Flag, Equals, uint(mysql.NotNullFlag | mysql.PriKeyFlag))
 }
 
 func (*testModelSuite) TestJobStartTime(c *C) {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -142,7 +142,7 @@ func (*testModelSuite) TestModelBasic(c *C) {
 	c.Assert(no, Equals, false)
 
 	extraPK := NewExtraHandleColInfo()
-	c.Assert(extraPK.Flag, Equals, uint(mysql.NotNullFlag | mysql.PriKeyFlag))
+	c.Assert(extraPK.Flag, Equals, uint(mysql.NotNullFlag|mysql.PriKeyFlag))
 }
 
 func (*testModelSuite) TestJobStartTime(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix https://github.com/pingcap/tics/issues/1509, where the extra PK 's not null flag is not right set.

### What is changed and how it works?
set the not null flag for extran PK

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
https://github.com/pingcap/tidb/pull/23237

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
