### PR TITLE
*: Add flush client_errors_summary for 4.0

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -643,6 +643,7 @@ const (
 	FlushTiDBPlugin
 	FlushHosts
 	FlushLogs
+	FlushClientErrorsSummary
 )
 
 // LogType is the log type used in FLUSH statement.
@@ -724,6 +725,8 @@ func (n *FlushStmt) Restore(ctx *format.RestoreCtx) error {
 			logType = "SLOW LOGS"
 		}
 		ctx.WriteKeyWord(logType)
+	case FlushClientErrorsSummary:
+		ctx.WriteKeyWord("CLIENT_ERRORS_SUMMARY")
 	default:
 		return errors.New("Unsupported type of FlushStmt")
 	}

--- a/misc.go
+++ b/misc.go
@@ -206,6 +206,7 @@ var tokenMap = map[string]int{
 	"CIPHER":                   cipher,
 	"CLEANUP":                  cleanup,
 	"CLIENT":                   client,
+	"CLIENT_ERRORS_SUMMARY":    clientErrorsSummary,
 	"CMSKETCH":                 cmSketch,
 	"COALESCE":                 coalesce,
 	"COLLATE":                  collate,

--- a/parser.y
+++ b/parser.y
@@ -319,6 +319,7 @@ import (
 	cipher                "CIPHER"
 	cleanup               "CLEANUP"
 	client                "CLIENT"
+	clientErrorsSummary   "CLIENT_ERRORS_SUMMARY"
 	coalesce              "COALESCE"
 	collation             "COLLATION"
 	columnFormat          "COLUMN_FORMAT"
@@ -5267,6 +5268,7 @@ UnReservedKeyword:
 |	"CSV_SEPARATOR"
 |	"ON_DUPLICATE"
 |	"TIKV_IMPORTER"
+|	"CLIENT_ERRORS_SUMMARY"
 
 TiDBKeyword:
 	"ADMIN"
@@ -9279,6 +9281,12 @@ FlushOption:
 			Tp:       ast.FlushTables,
 			Tables:   $2.([]*ast.TableName),
 			ReadLock: $3.(bool),
+		}
+	}
+|	"CLIENT_ERRORS_SUMMARY"
+	{
+		$$ = &ast.FlushStmt{
+			Tp: ast.FlushClientErrorsSummary,
 		}
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1096,6 +1096,7 @@ func (s *testParserSuite) TestDBAStmt(c *C) {
 		{"flush error logs", true, "FLUSH ERROR LOGS"},
 		{"flush general logs", true, "FLUSH GENERAL LOGS"},
 		{"flush slow logs", true, "FLUSH SLOW LOGS"},
+		{"flush client_errors_summary", true, "FLUSH CLIENT_ERRORS_SUMMARY"},
 
 		// for change statement
 		{"change pump to node_state ='paused' for node_id '127.0.0.1:8250'", true, "CHANGE PUMP TO NODE_STATE ='paused' FOR NODE_ID '127.0.0.1:8250'"},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Implements https://github.com/pingcap/parser/pull/1154 for release-4.0 branch.

### What is changed and how it works?

A new `FLUSH CLIENT_ERRORS_SUMMARY` statement is added.

The corresponding PR in TiDB is https://github.com/pingcap/tidb/pull/23267

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 -  PR against master: https://github.com/pingcap/parser/pull/1154
 - TiDB PR: https://github.com/pingcap/tidb/pull/23267
 