### PR TITLE
parser, ast: add explain for ALTER TABLE stmts

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -249,7 +249,7 @@ func (n *ExplainStmt) Accept(v Visitor) (Node, bool) {
 	if !ok {
 		return n, false
 	}
-	n.Stmt = node.(DMLNode)
+	n.Stmt = node.(StmtNode)
 	return v.Leave(n)
 }
 

--- a/parser.y
+++ b/parser.y
@@ -10364,6 +10364,7 @@ ExplainableStmt:
 |	InsertIntoStmt
 |	ReplaceIntoStmt
 |	SetOprStmt1
+|	AlterTableStmt
 
 StatementList:
 	Statement

--- a/parser_test.go
+++ b/parser_test.go
@@ -4370,6 +4370,8 @@ func (s *testParserSuite) TestExplain(c *C) {
 		{"EXPLAIN FORMAT = JSON FOR CONNECTION 1", true, "EXPLAIN FORMAT = 'json' FOR CONNECTION 1"},
 		{"EXPLAIN FORMAT = JSON SELECT 1", true, "EXPLAIN FORMAT = 'json' SELECT 1"},
 		{"EXPLAIN FORMAT = 'hint' SELECT 1", true, "EXPLAIN FORMAT = 'hint' SELECT 1"},
+		{"EXPLAIN ALTER TABLE t1 ADD INDEX (a)", true, "EXPLAIN FORMAT = 'row' ALTER TABLE `t1` ADD INDEX(`a`)"},
+		{"EXPLAIN ALTER TABLE t1 ADD a varchar(255)", true, "EXPLAIN FORMAT = 'row' ALTER TABLE `t1` ADD COLUMN `a` VARCHAR(255)"},
 	}
 	s.RunTest(c, table)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

As part of change column type (but also other operations) it is difficult to know what happens when a DDL operation is performed. MySQL supports explain assertions, but these are a little limited.

In chatting to @bb7133 we discussed adding an `EXPLAIN` for DDL.  The TiDB issue is https://github.com/pingcap/tidb/issues/8429

This is an extension to MySQL syntax.

### What is changed and how it works?

Alter table statements are now explainable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects

 - Increased code complexity

Related changes

- None