### PR TITLE
auth: fix CheckScrambledPassword() panic for invalid input

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -103,6 +103,9 @@ func CheckScrambledPassword(salt, hpwd, auth []byte) bool {
 	terror.Log(errors.Trace(err))
 	hash := crypt.Sum(nil)
 	// token = scrambleHash XOR stage1Hash
+	if len(auth) != len(hash) {
+		return false
+	}
 	for i := range hash {
 		hash[i] ^= auth[i]
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -45,6 +45,6 @@ func (s *testAuthSuite) TestCheckScramble(c *C) {
 	c.Assert(res, IsTrue)
 
 	// Do not panic for invalid input.
-	res := CheckScrambledPassword(salt, hpwd, []byte("xxyyzz"))
-	c.Assert(res, False)
+	res = CheckScrambledPassword(salt, hpwd, []byte("xxyyzz"))
+	c.Assert(res, IsFalse)
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -43,4 +43,8 @@ func (s *testAuthSuite) TestCheckScramble(c *C) {
 
 	res := CheckScrambledPassword(salt, hpwd, auth)
 	c.Assert(res, IsTrue)
+
+	// Do not panic for invalid input.
+	res := CheckScrambledPassword(salt, hpwd, []byte("xxyyzz"))
+	c.Assert(res, False)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

![image](https://user-images.githubusercontent.com/1420062/112284913-b6021300-8cc4-11eb-9eeb-a60110e1d022.png)

### What is changed and how it works?

The input data may be invalid, but calling `CheckScrambledPassword()` on malformed data should not make TiDB server panic.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
