### PR TITLE
mysql: modify TypeNewDecimal length in defaultLengthAndDecimalForCast

### DIFF
--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -81,7 +81,7 @@ func (ts *testAstFormatSuite) TestAstFormat(c *C) {
 		{` cast( a as signed ) `, "CAST(`a` AS SIGNED)"},
 		{` cast( a as unsigned integer) `, "CAST(`a` AS UNSIGNED)"},
 		{` cast( a as char(3) binary) `, "CAST(`a` AS BINARY(3))"},
-		{` cast( a as decimal ) `, "CAST(`a` AS DECIMAL(11))"},
+		{` cast( a as decimal ) `, "CAST(`a` AS DECIMAL(10))"},
 		{` cast( a as decimal (3) ) `, "CAST(`a` AS DECIMAL(3))"},
 		{` cast( a as decimal (3,3) ) `, "CAST(`a` AS DECIMAL(3, 3))"},
 		{` ((case when (c0 = 0) then 0 when (c0 > 0) then (c1 / c0) end)) `, "((CASE WHEN (`c0` = 0) THEN 0 WHEN (`c0` > 0) THEN (`c1` / `c0`) END))"},

--- a/mysql/util.go
+++ b/mysql/util.go
@@ -76,7 +76,7 @@ var defaultLengthAndDecimalForCast = map[byte]lengthAndDecimal{
 	TypeString:     {0, -1}, // Flen & Decimal differs.
 	TypeDate:       {10, 0},
 	TypeDatetime:   {19, 0},
-	TypeNewDecimal: {11, 0},
+	TypeNewDecimal: {10, 0},
 	TypeDuration:   {10, 0},
 	TypeLonglong:   {22, 0},
 	TypeDouble:     {22, -1},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/23495 in TiDB


### What is changed and how it works?

modify TypeNewDecimal length in defaultLengthAndDecimalForCast from 11 to 10. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
