### PR TITLE
ast: visit Join.Using in Join.Accept

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -246,6 +246,13 @@ func (n *Join) Accept(v Visitor) (Node, bool) {
 		}
 		n.On = node.(*OnCondition)
 	}
+	for i, col := range n.Using {
+		node, ok = col.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.Using[i] = node.(*ColumnName)
+	}
 	return v.Leave(n)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`ast.Join.Accept` should visit its field `Using`

### What is changed and how it works?
A for loop is added to `ast.Join.Accept` for visiting all nodes in the slice `Using`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

`make test` passes in repo `pingcap/tidb` while replace `pingcap/parser` to `pragmatwice/parser@patch-ast-dml-join-accept`

```
...
Great, all tests passed.
```

Code changes

 - Has interface methods change

Side effects

 - Breaking backward compatibility

