### PR TITLE
ast: make ResultSetNode different from Node

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -137,9 +137,11 @@ type ResultField struct {
 }
 
 // ResultSetNode interface has a ResultFields property, represents a Node that returns result set.
-// Implementations include SelectStmt, SubqueryExpr, TableSource, TableName and Join.
+// Implementations include SelectStmt, SubqueryExpr, TableSource, TableName, Join and SetOprStmt.
 type ResultSetNode interface {
 	Node
+
+	resultSet()
 }
 
 // SensitiveStmtNode overloads StmtNode and provides a SecureText method.

--- a/ast/dml.go
+++ b/ast/dml.go
@@ -88,6 +88,8 @@ type Join struct {
 	ExplicitParens bool
 }
 
+func (*Join) resultSet() {}
+
 // NewCrossJoin builds a cross join without `on` or `using` clause.
 // If the right child is a join tree, we need to handle it differently to make the precedence get right.
 // Here is the example: t1 join t2 join t3
@@ -273,6 +275,8 @@ type TableName struct {
 	// AS OF is used to see the data as it was at a specific point in time.
 	AsOf *AsOfClause
 }
+
+func (*TableName) resultSet() {}
 
 // Restore implements Node interface.
 func (n *TableName) restoreName(ctx *format.RestoreCtx) {
@@ -497,6 +501,8 @@ type TableSource struct {
 	// AsName is the alias name of the table source.
 	AsName model.CIStr
 }
+
+func (*TableSource) resultSet() {}
 
 // Restore implements Node interface.
 func (n *TableSource) Restore(ctx *format.RestoreCtx) error {
@@ -1074,6 +1080,8 @@ type SelectStmt struct {
 	With  *WithClause
 }
 
+func (*SelectStmt) resultSet() {}
+
 func (n *WithClause) Restore(ctx *format.RestoreCtx) error {
 	ctx.WriteKeyWord("WITH ")
 	if n.IsRecursive {
@@ -1485,6 +1493,8 @@ type SetOprStmt struct {
 	Limit      *Limit
 	With       *WithClause
 }
+
+func (*SetOprStmt) resultSet() {}
 
 // Restore implements Node interface.
 func (n *SetOprStmt) Restore(ctx *format.RestoreCtx) error {

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -364,6 +364,8 @@ type SubqueryExpr struct {
 	Exists     bool
 }
 
+func (*SubqueryExpr) resultSet() {}
+
 // Restore implements Node interface.
 func (n *SubqueryExpr) Restore(ctx *format.RestoreCtx) error {
 	ctx.WritePlain("(")

--- a/parser.y
+++ b/parser.y
@@ -3974,7 +3974,7 @@ CreateTableSelectOpt:
 	}
 |	SetOprStmt1
 	{
-		$$ = &ast.CreateTableStmt{Select: $1}
+		$$ = &ast.CreateTableStmt{Select: $1.(ast.ResultSetNode)}
 	}
 
 CreateViewSelectOpt:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
For now, `ResultSetNode` is exactly the same as  `Node`, thus we cannot distinguish them in a dynamic context (without `reflect` and some user-space ad hoc methods).

To solve it, we can add a private method to `ResultSetNode`, just like `StmtNode`, `DDLNode`, `DMLNode` or others.

### What is changed and how it works?
A new private method named `ResultSetNode.resultSet()`, implemented by `SelectStmt`, `SubqueryExpr`, `TableSource`, `TableName`, `Join` and `SetOprStmt`.

And a dynamic cast should be added to the parser for casting from `StmtNode` to `ResultSetNode`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit tests have passed
- Integration testing has been broken by previous commits

Code changes

 - Has interface methods change
