### PR TITLE
parser: Fix tidb issue 24439 Inconsistent error with MySQL for GRANT CREATE USER ON <specific db>.*

### DIFF
--- a/mysql/privs.go
+++ b/mysql/privs.go
@@ -184,7 +184,7 @@ func (p PrivilegeType) String() string {
 	return ""
 }
 
-// ColumnString returns the corresponding name of columns in mysql.user/db.
+// ColumnString returns the corresponding name of columns in mysql.user/mysql.db.
 func (p PrivilegeType) ColumnString() string {
 	if s, ok := Priv2UserCol[p]; ok {
 		return s
@@ -192,7 +192,7 @@ func (p PrivilegeType) ColumnString() string {
 	return ""
 }
 
-// SetString returns the corresponding set enum string in Table_priv/Column_priv of mysql.tables_priv/columns_priv.
+// SetString returns the corresponding set enum string in Table_priv/Column_priv of mysql.tables_priv/mysql.columns_priv.
 func (p PrivilegeType) SetString() string {
 	if s, ok := Priv2SetStr[p]; ok {
 		return s

--- a/mysql/privs.go
+++ b/mysql/privs.go
@@ -184,7 +184,7 @@ func (p PrivilegeType) String() string {
 	return ""
 }
 
-// ColumnString returns the corresponding name of columns in mysql.user/mysql.db.
+// ColumnString returns the corresponding name of columns in mysql.user/db.
 func (p PrivilegeType) ColumnString() string {
 	if s, ok := Priv2UserCol[p]; ok {
 		return s
@@ -192,7 +192,7 @@ func (p PrivilegeType) ColumnString() string {
 	return ""
 }
 
-// SetString returns the corresponding set enum string in Table_priv/Column_priv of mysql.tables_priv/mysql.columns_priv.
+// SetString returns the corresponding set enum string in Table_priv/Column_priv of mysql.tables_priv/columns_priv.
 func (p PrivilegeType) SetString() string {
 	if s, ok := Priv2SetStr[p]; ok {
 		return s
@@ -304,3 +304,6 @@ var AllTablePrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv, DeletePriv, C
 
 // AllColumnPrivs is all the privileges in column scope.
 var AllColumnPrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv}
+
+// StaticGlobalOnlyPrivs is all the privileges only in global scope and different from dynamic privileges.
+var StaticGlobalOnlyPrivs = Privileges{ProcessPriv, ShowDBPriv, SuperPriv, CreateUserPriv, CreateTablespacePriv, ShutdownPriv, ReloadPriv, FilePriv, ReplicationClientPriv, ReplicationSlavePriv, ConfigPriv}

--- a/mysql/privs_test.go
+++ b/mysql/privs_test.go
@@ -38,6 +38,12 @@ func (s *testPrivsSuite) TestPrivColumn(c *C) {
 		c.Assert(ok, IsTrue, Commentf("%s", p))
 		c.Assert(np, Equals, p)
 	}
+	for _, p := range StaticGlobalOnlyPrivs {
+		c.Assert(p.ColumnString(), Not(Equals), "", Commentf("%s", p))
+		np, ok := NewPrivFromColumn(p.ColumnString())
+		c.Assert(ok, IsTrue, Commentf("%s", p))
+		c.Assert(np, Equals, p)
+	}
 	for _, p := range AllDBPrivs {
 		c.Assert(p.ColumnString(), Not(Equals), "", Commentf("%s", p))
 		np, ok := NewPrivFromColumn(p.ColumnString())


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
 Fix mysql grant action compatibility
related to https://github.com/pingcap/tidb/issues/24439
related to https://github.com/pingcap/tidb/pull/24485

### What is changed and how it works?
Add  StaticGlobalOnlyPrivs in privs.go


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
