### PR TITLE
Fix running of auth tests

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -14,12 +14,18 @@
 package auth
 
 import (
+	"testing"
+
 	. "github.com/pingcap/check"
 )
 
 var _ = Suite(&testAuthSuite{})
 
 type testAuthSuite struct {
+}
+
+func TestT(t *testing.T) {
+	TestingT(t)
 }
 
 func (s *testAuthSuite) TestEncodePassword(c *C) {

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,14 @@
+#!/bin/sh
+
+# If 'check.TestingT' is not used in any of the *_test.go files in a subdir no tests will run.
+
+for f in $(git grep -l 'github.com/pingcap/check' | grep '/' | cut -d/ -f1 | uniq)
+do
+	if ! grep -r TestingT "$f" > /dev/null
+	then
+		echo "check.TestingT missing from $f"
+		exit 1
+	fi
+done
+
 GO111MODULE=on go test -p 1 -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The tests in `auth/auth_test.go` were not run.

To see the issue modify `auth/auth_test.go` to make a test case that should fail. Then run `make test`. The expected outcome is a failed test run, but in fact it doesn't show any errors.

### What is changed and how it works?

- This adds `check.TestingT()` to `auth/auth_test.go`
- This adds a simple check in `test.sh` to test for similar cases.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
