### PR TITLE
lexer: fix the bug that lexer may scan wrong tokens

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -156,7 +156,6 @@ func (s *Scanner) Lex(v *yySymType) int {
 		tok == stringLit &&
 		s.r.s[v.offset] == '"' {
 		tok = identifier
-		s.identifierDot = false
 	}
 
 	if tok == pipes && !(s.sqlMode.HasPipesAsConcatMode()) {
@@ -183,8 +182,9 @@ func (s *Scanner) Lex(v *yySymType) int {
 		return tok
 	case null:
 		v.item = nil
-	case quotedIdentifier:
+	case quotedIdentifier, identifier:
 		tok = identifier
+		s.identifierDot = s.r.peek() == '.'
 	}
 
 	if tok == unicode.ReplacementChar {
@@ -490,7 +490,6 @@ func startWithAt(s *Scanner) (tok int, pos Pos, lit string) {
 func scanIdentifier(s *Scanner) (int, Pos, string) {
 	pos := s.r.pos()
 	s.r.incAsLongAs(isIdentChar)
-	s.identifierDot = s.r.peek() == '.'
 	return identifier, pos, s.r.data(&pos)
 }
 
@@ -531,7 +530,6 @@ func scanQuotedIdent(s *Scanner) (tok int, pos Pos, lit string) {
 			if s.r.peek() != '`' {
 				// don't return identifier in case that it's interpreted as keyword token later.
 				tok, lit = quotedIdentifier, s.buf.String()
-				s.identifierDot = false
 				return
 			}
 			s.r.inc()

--- a/lexer.go
+++ b/lexer.go
@@ -156,6 +156,7 @@ func (s *Scanner) Lex(v *yySymType) int {
 		tok == stringLit &&
 		s.r.s[v.offset] == '"' {
 		tok = identifier
+		s.identifierDot = false
 	}
 
 	if tok == pipes && !(s.sqlMode.HasPipesAsConcatMode()) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -992,6 +992,9 @@ AAAAAAAAAAAA5gm5Mg==
 		{"CREATE SEQUENCE seq INCREMENT - 9223372036854775808", true, "CREATE SEQUENCE `seq` INCREMENT BY -9223372036854775808"},
 		{"CREATE SEQUENCE seq INCREMENT -9223372036854775808", true, "CREATE SEQUENCE `seq` INCREMENT BY -9223372036854775808"},
 		{"CREATE SEQUENCE seq INCREMENT -9223372036854775809", false, ""},
+
+		{"select `t`.`1a`.1 from t;", true, "SELECT `t`.`1a`.`1` FROM `t`"},
+		{"select * from 1db.1table;", true, "SELECT * FROM `1db`.`1table`"},
 	}
 	s.RunTest(c, table)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -306,6 +306,17 @@ func (s *testParserSuite) TestSimple(c *C) {
 	c.Assert(bExpr.L.(*ast.ColumnNameExpr).Name.Name.O, Equals, "a")
 	c.Assert(bExpr.L.(*ast.ColumnNameExpr).Name.Table.O, Equals, "t")
 	c.Assert(bExpr.R.(ast.ValueExpr).GetValue().(int64), Equals, int64(10))
+
+	parser.SetSQLMode(mysql.ModeANSIQuotes)
+	src = `select t."dot"=10 from t;`
+	st, err = parser.ParseOneStmt(src, "", "")
+	c.Assert(err, IsNil)
+	bExpr, ok = st.(*ast.SelectStmt).Fields.Fields[0].Expr.(*ast.BinaryOperationExpr)
+	c.Assert(ok, IsTrue)
+	c.Assert(bExpr.Op, Equals, opcode.EQ)
+	c.Assert(bExpr.L.(*ast.ColumnNameExpr).Name.Name.O, Equals, "dot")
+	c.Assert(bExpr.L.(*ast.ColumnNameExpr).Name.Table.O, Equals, "t")
+	c.Assert(bExpr.R.(ast.ValueExpr).GetValue().(int64), Equals, int64(10))
 }
 
 func (s *testParserSuite) TestSpecialComments(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close https://github.com/pingcap/parser/issues/1203
cherry-pick https://github.com/pingcap/parser/pull/1228

`identifierDot` should be true if and only if a dot after an identifier, if it is true, the next token must be interpreted as identifier or '*'

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

