### PR TITLE
fix restore for count(*)

### DIFF
--- a/ast/functions_test.go
+++ b/ast/functions_test.go
@@ -128,7 +128,7 @@ func (ts *testFunctionsSuite) TestAggregateFuncExprRestore(c *C) {
 		{"BIT_OR(test_score)", "BIT_OR(`test_score`)"},
 		{"BIT_XOR(test_score)", "BIT_XOR(`test_score`)"},
 		{"COUNT(test_score)", "COUNT(`test_score`)"},
-		{"COUNT(*)", "COUNT(1)"},
+		{"COUNT(*)", "COUNT(*)"},
 		{"COUNT(DISTINCT scores, results)", "COUNT(DISTINCT `scores`, `results`)"},
 		{"MIN(test_score)", "MIN(`test_score`)"},
 		{"MIN(DISTINCT test_score)", "MIN(DISTINCT `test_score`)"},
@@ -150,7 +150,7 @@ func (ts *testFunctionsSuite) TestAggregateFuncExprRestore(c *C) {
 		{"GROUP_CONCAT(a order by b desc, c separator '--')", "GROUP_CONCAT(`a` ORDER BY `b` DESC,`c` SEPARATOR '--')"},
 	}
 	extractNodeFunc := func(node Node) Node {
-		return node.(*SelectStmt).Fields.Fields[0].Expr
+		return node.(*SelectStmt).Fields.Fields[0]
 	}
 	RunNodeRestoreTest(c, testCases, "select %s", extractNodeFunc)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -1986,7 +1986,7 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{`select count(c1) from t;`, true, "SELECT COUNT(`c1`) FROM `t`"},
 		{`select count(distinct *) from t;`, false, ""},
 		{`select count(distinctrow *) from t;`, false, ""},
-		{`select count(*) from t;`, true, "SELECT COUNT(1) FROM `t`"},
+		{`select count(*) from t;`, true, "SELECT COUNT(*) FROM `t`"},
 		{`select count(distinct c1, c2) from t;`, true, "SELECT COUNT(DISTINCT `c1`, `c2`) FROM `t`"},
 		{`select count(distinctrow c1, c2) from t;`, true, "SELECT COUNT(DISTINCT `c1`, `c2`) FROM `t`"},
 		{`select count(c1, c2) from t;`, false, ""},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Before this commit, `select count(*) from t ` will be restored to `select count(1) from t`.
After this commit, `select count(*) from t ` can be restored to `select count(*) from t` correctly

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch