### PR TITLE
auth: Fix salt generation of caching_sha2_password

### DIFF
--- a/auth/caching_sha2.go
+++ b/auth/caching_sha2.go
@@ -205,8 +205,15 @@ func CheckShaPassword(pwhash []byte, password string) (bool, error) {
 func NewSha2Password(pwd string) string {
 	salt := make([]byte, SALT_LENGTH)
 	rand.Read(salt)
+
+	// Restrict to 7-bit to avoid multi-byte UTF-8
 	for i := range salt {
-		salt[i] = salt[i] ^ 128
+		salt[i] = salt[i] &^ 128
+		if salt[i] == 36 { // '$'
+			newval := make([]byte, 1)
+			rand.Read(newval)
+			salt[i] = newval[0]
+		}
 	}
 
 	return sha256crypt(pwd, salt, 5*ITERATION_MULTIPLIER)

--- a/auth/caching_sha2_test.go
+++ b/auth/caching_sha2_test.go
@@ -64,4 +64,8 @@ func (s *testAuthSuite) TestNewSha2Password(c *C) {
 	r, err := CheckShaPassword([]byte(pwhash), pwd)
 	c.Assert(err, IsNil)
 	c.Assert(r, IsTrue)
+
+	for r := range pwhash {
+		c.Assert(r < 128, IsTrue)
+	}
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

This code intended to set the first bit of every byte of the salt
to 0 as the salt should not contain multi-byte UTF-8.

### What is changed and how it works?

However it failed to do this. This changes the `^` with a `^&` to fix
that.

In addition to that this also avoids the '$' inside salts as that is
already used as delimiter in the authentication string.

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->






### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

This is related to https://github.com/pingcap/tidb/pull/24991




