### PR TITLE
auth: check for NUL in caching_sha2_password salt

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -1109,6 +1109,11 @@ func (n *UserSpec) EncodedPassword() (string, bool) {
 		}
 	}
 
+	// In case we have 'IDENTIFIED WITH <plugin>' but no 'BY <password>' to set an empty password.
+	if opt.HashString == "" {
+		return opt.HashString, true
+	}
+
 	// Not a legal password string.
 	switch opt.AuthPlugin {
 	case mysql.AuthCachingSha2Password:

--- a/auth/caching_sha2.go
+++ b/auth/caching_sha2.go
@@ -209,7 +209,7 @@ func NewSha2Password(pwd string) string {
 	// Restrict to 7-bit to avoid multi-byte UTF-8
 	for i := range salt {
 		salt[i] = salt[i] &^ 128
-		if salt[i] == 36 { // '$'
+		if salt[i] == 36 || salt[i] == 0 { // '$' or NUL
 			newval := make([]byte, 1)
 			rand.Read(newval)
 			salt[i] = newval[0]

--- a/parser_test.go
+++ b/parser_test.go
@@ -3903,6 +3903,8 @@ func (s *testParserSuite) TestPrivilege(c *C) {
 		{"CREATE USER 'sha_test'@'localhost' IDENTIFIED WITH 'caching_sha2_password' BY 'sha_test'", true, "CREATE USER `sha_test`@`localhost` IDENTIFIED WITH 'caching_sha2_password' BY 'sha_test'"},
 		{"CREATE USER 'sha_test3'@'localhost' IDENTIFIED WITH 'caching_sha2_password' AS 0x24412430303524255B03496C662C1055127B3B654A2F04207D01485276703644704B76303247474564416A516662346C5868646D32764C6B514F43585A473779565947514F34", true, "CREATE USER `sha_test3`@`localhost` IDENTIFIED WITH 'caching_sha2_password' AS '$A$005$%[\x03Ilf,\x10U\x12{;eJ/\x04 }\x01HRvp6DpKv02GGEdAjQfb4lXhdm2vLkQOCXZG7yVYGQO4'"},
 		{"CREATE USER 'sha_test4'@'localhost' IDENTIFIED WITH 'caching_sha2_password' AS '$A$005$%[\x03Ilf,\x10U\x12{;eJ/\x04 }\x01HRvp6DpKv02GGEdAjQfb4lXhdm2vLkQOCXZG7yVYGQO4'", true, "CREATE USER `sha_test4`@`localhost` IDENTIFIED WITH 'caching_sha2_password' AS '$A$005$%[\x03Ilf,\x10U\x12{;eJ/\x04 }\x01HRvp6DpKv02GGEdAjQfb4lXhdm2vLkQOCXZG7yVYGQO4'"},
+		{"CREATE USER 'nopwd_native'@'localhost' IDENTIFIED WITH 'mysql_native_password'", true, "CREATE USER `nopwd_native`@`localhost` IDENTIFIED WITH 'mysql_native_password'"},
+		{"CREATE USER 'nopwd_sha'@'localhost' IDENTIFIED WITH 'caching_sha2_password'", true, "CREATE USER `nopwd_sha`@`localhost` IDENTIFIED WITH 'caching_sha2_password'"},
 		{"CREATE ROLE `test-role`, `role1`@'localhost'", true, "CREATE ROLE `test-role`@`%`, `role1`@`localhost`"},
 		{"CREATE ROLE `test-role`", true, "CREATE ROLE `test-role`@`%`"},
 		{"CREATE ROLE role1", true, "CREATE ROLE `role1`@`%`"},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This fixes issues found in the JDBC test cases:
- Allow `CREATE USER ... IDENTIFIED WITH <auth_method>` (without `'BY <password>`)

This also includes a fix for `NUL` in salts that was meant to be included in another PR but accidentally wasn't pushed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test



