### PR TITLE
auth: caching_sha2_password salt fix

### DIFF
--- a/auth/caching_sha2.go
+++ b/auth/caching_sha2.go
@@ -209,10 +209,10 @@ func NewSha2Password(pwd string) string {
 	// Restrict to 7-bit to avoid multi-byte UTF-8
 	for i := range salt {
 		salt[i] = salt[i] &^ 128
-		if salt[i] == 36 || salt[i] == 0 { // '$' or NUL
+		for salt[i] == 36 || salt[i] == 0 { // '$' or NUL
 			newval := make([]byte, 1)
 			rand.Read(newval)
-			salt[i] = newval[0]
+			salt[i] = newval[0] &^ 128
 		}
 	}
 

--- a/auth/caching_sha2_test.go
+++ b/auth/caching_sha2_test.go
@@ -66,6 +66,8 @@ func (s *testAuthSuite) TestNewSha2Password(c *C) {
 	c.Assert(r, IsTrue)
 
 	for r := range pwhash {
-		c.Assert(r < 128, IsTrue)
+		c.Assert(pwhash[r], Less, uint8(128))
+		c.Assert(pwhash[r], Not(Equals), 0)  // NUL
+		c.Assert(pwhash[r], Not(Equals), 36) // '$'
 	}
 }


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

- a NUL or '$' could get replaced with another NUL or '$'
- Replacement characters didn't get their first bit set to 0 (`&^ 128`)
- The test case used the index number instead of the value of the rune.

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->



Related to https://github.com/pingcap/tidb/pull/24991


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test



