### PR TITLE
parser: ensure NOT NOT EXISTS is the same as EXISTS (#1254)

### DIFF
--- a/ast/expressions_test.go
+++ b/ast/expressions_test.go
@@ -363,6 +363,8 @@ func (tc *testExpressionsSuite) TestExistsSubqueryExprRestore(c *C) {
 	testCases := []NodeRestoreTestCase{
 		{"EXISTS (SELECT 2)", "EXISTS (SELECT 2)"},
 		{"NOT EXISTS (SELECT 2)", "NOT EXISTS (SELECT 2)"},
+		{"NOT NOT EXISTS (SELECT 2)", "EXISTS (SELECT 2)"},
+		{"NOT NOT NOT EXISTS (SELECT 2)", "NOT EXISTS (SELECT 2)"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*SelectStmt).Where

--- a/parser.y
+++ b/parser.y
@@ -4882,7 +4882,7 @@ Expression:
 	{
 		expr, ok := $2.(*ast.ExistsSubqueryExpr)
 		if ok {
-			expr.Not = true
+			expr.Not = !expr.Not
 			$$ = $2
 		} else {
 			$$ = &ast.UnaryOperationExpr{Op: opcode.Not, V: $2}


### PR DESCRIPTION
Cherry-pick #1254 to release-5.0

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #1251 

### What is changed and how it works?

When applying NOT to an ExistsSubqueryExpr, flip its `Not` flag instead of always setting it to `true`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
    * `NOT NOT EXISTS (SELECT ...)` is now correctly interpreted as `EXISTS (SELECT ...)`.
