### PR TITLE
Remove useless const AddIndexStr,AddPrimaryKeyStr

### DIFF
--- a/model/ddl.go
+++ b/model/ddl.go
@@ -81,12 +81,6 @@ const (
 	ActionDropIndexes                   ActionType = 48
 )
 
-const (
-	// AddIndexStr is a string related to the operation of "add index".
-	AddIndexStr      = "add index"
-	AddPrimaryKeyStr = "add primary key"
-)
-
 var actionMap = map[ActionType]string{
 	ActionCreateSchema:                  "create schema",
 	ActionDropSchema:                    "drop schema",
@@ -94,7 +88,7 @@ var actionMap = map[ActionType]string{
 	ActionDropTable:                     "drop table",
 	ActionAddColumn:                     "add column",
 	ActionDropColumn:                    "drop column",
-	ActionAddIndex:                      AddIndexStr,
+	ActionAddIndex:                      "add index",
 	ActionDropIndex:                     "drop index",
 	ActionAddForeignKey:                 "add foreign key",
 	ActionDropForeignKey:                "drop foreign key",
@@ -119,7 +113,7 @@ var actionMap = map[ActionType]string{
 	ActionRepairTable:                   "repair table",
 	ActionSetTiFlashReplica:             "set tiflash replica",
 	ActionUpdateTiFlashReplicaStatus:    "update tiflash replica status",
-	ActionAddPrimaryKey:                 AddPrimaryKeyStr,
+	ActionAddPrimaryKey:                 "add primary key",
 	ActionDropPrimaryKey:                "drop primary key",
 	ActionCreateSequence:                "create sequence",
 	ActionAlterSequence:                 "alter sequence",


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Related to https://github.com/pingcap/tidb/issues/25507

### What is changed and how it works?

Seems that we don't need to export the const `AddIndexStr` nor `AddPrimaryKeyStr` anymore after https://github.com/pingcap/tidb/pull/26218

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has exported variable/fields change

Side effects

 - N/A

Related changes

 - N/A
