### PR TITLE
goyacc: add a config option to skip text position recording

### DIFF
--- a/goyacc/main.go
+++ b/goyacc/main.go
@@ -790,7 +790,7 @@ yynewstate:
 	mustFormat(f, `%u
 	}
 
-	if !parser.skipPositionRecording {
+	if !parser.lexer.skipPositionRecording {
 		%[1]sSetOffset(parser.yyVAL, parser.yyVAL.offset)
 	}
 

--- a/goyacc/main.go
+++ b/goyacc/main.go
@@ -790,8 +790,9 @@ yynewstate:
 	mustFormat(f, `%u
 	}
 
-
-	%[1]sSetOffset(parser.yyVAL, parser.yyVAL.offset)
+	if !parser.skipPositionRecording {
+		%[1]sSetOffset(parser.yyVAL, parser.yyVAL.offset)
+	}
 
 	if yyEx != nil && yyEx.Reduced(r, exState, parser.yyVAL) {
 		return -1

--- a/hintparser.go
+++ b/hintparser.go
@@ -1321,7 +1321,9 @@ yynewstate:
 
 	}
 
-	yyhintSetOffset(parser.yyVAL, parser.yyVAL.offset)
+	if !parser.skipPositionRecording {
+		yyhintSetOffset(parser.yyVAL, parser.yyVAL.offset)
+	}
 
 	if yyEx != nil && yyEx.Reduced(r, exState, parser.yyVAL) {
 		return -1

--- a/hintparser.go
+++ b/hintparser.go
@@ -1321,7 +1321,7 @@ yynewstate:
 
 	}
 
-	if !parser.skipPositionRecording {
+	if !parser.lexer.skipPositionRecording {
 		yyhintSetOffset(parser.yyVAL, parser.yyVAL.offset)
 	}
 

--- a/lexer.go
+++ b/lexer.go
@@ -54,6 +54,9 @@ type Scanner struct {
 	// because some application may already use them as identifiers.
 	supportWindowFunc bool
 
+	// Whether record the original text keyword position to the AST node.
+	skipPositionRecording bool
+
 	// lastScanOffset indicates last offset returned by scan().
 	// It's used to substring sql in syntax error message.
 	lastScanOffset int

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -71,6 +71,7 @@ func TrimComment(txt string) string {
 type ParserConfig struct {
 	EnableWindowFunction        bool
 	EnableStrictDoubleTypeCheck bool
+	SkipPositionRecording       bool
 }
 
 // Parser represents a parser instance. Some temporary objects are stored in it to reduce object allocation during Parse function.
@@ -84,6 +85,7 @@ type Parser struct {
 
 	explicitCharset       bool
 	strictDoubleFieldType bool
+	skipPositionRecording bool // Whether record the original text keyword position to the AST node.
 
 	// the following fields are used by yyParse to reduce allocation.
 	cache  []yySymType
@@ -130,6 +132,7 @@ func (parser *Parser) SetStrictDoubleTypeCheck(val bool) {
 func (parser *Parser) SetParserConfig(config ParserConfig) {
 	parser.EnableWindowFunc(config.EnableWindowFunction)
 	parser.SetStrictDoubleTypeCheck(config.EnableStrictDoubleTypeCheck)
+	parser.skipPositionRecording = config.SkipPositionRecording
 }
 
 // Parse parses a query string to raw ast.StmtNode.

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -85,7 +85,6 @@ type Parser struct {
 
 	explicitCharset       bool
 	strictDoubleFieldType bool
-	skipPositionRecording bool // Whether record the original text keyword position to the AST node.
 
 	// the following fields are used by yyParse to reduce allocation.
 	cache  []yySymType
@@ -132,7 +131,7 @@ func (parser *Parser) SetStrictDoubleTypeCheck(val bool) {
 func (parser *Parser) SetParserConfig(config ParserConfig) {
 	parser.EnableWindowFunc(config.EnableWindowFunction)
 	parser.SetStrictDoubleTypeCheck(config.EnableStrictDoubleTypeCheck)
-	parser.skipPositionRecording = config.SkipPositionRecording
+	parser.lexer.skipPositionRecording = config.SkipPositionRecording
 }
 
 // Parse parses a query string to raw ast.StmtNode.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/pingcap/parser/pull/984 may introduce an incorrect implementation: it may write the AST nodes parsed previously. For details, see https://github.com/pingcap/tidb/issues/26538#issuecomment-893316891.

### What is changed and how it works?

This PR provides an option to skip position recording.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported variable/fields change

Side effects

NA

Related changes

 - Need to cherry-pick to the release branch
