### PR TITLE
charset: clean up some code about charset

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -15,6 +15,7 @@ package charset
 
 import (
 	"strings"
+	"sync/atomic"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
@@ -24,7 +25,28 @@ import (
 var (
 	ErrUnknownCollation         = terror.ClassDDL.NewStd(mysql.ErrUnknownCollation)
 	ErrCollationCharsetMismatch = terror.ClassDDL.NewStd(mysql.ErrCollationCharsetMismatch)
+
+	// enableCharsetFeat is 1 indicate the charset feature is enabled.
+	enableCharsetFeat = int32(0)
 )
+
+func EnableCharsetFeat() {
+	SetCharsetFratEnabledForTest(true)
+}
+
+// SetCharsetFratEnabledForTest set charset feature enabled. Only used in test.
+func SetCharsetFratEnabledForTest(flag bool) {
+	if flag {
+		atomic.StoreInt32(&enableCharsetFeat, 1)
+		return
+	}
+	atomic.StoreInt32(&enableCharsetFeat, 0)
+}
+
+// CharsetFeatEnabled return true if charset feature is enabled.
+func CharsetFeatEnabled() bool {
+	return atomic.LoadInt32(&enableCharsetFeat) == 1
+}
 
 // Charset is a charset.
 // Now we only support MySQL.
@@ -45,19 +67,22 @@ type Collation struct {
 	IsDefault   bool
 }
 
-var charsets = make(map[string]*Charset)
 var collationsIDMap = make(map[int]*Collation)
 var collationsNameMap = make(map[string]*Collation)
-var descs = make([]*Desc, 0, len(charsetInfos))
 var supportedCollations = make([]*Collation, 0, len(supportedCollationNames))
 
 // All the supported charsets should be in the following table.
-var charsetInfos = []*Charset{
-	{CharsetUTF8, CollationUTF8, make(map[string]*Collation), "UTF-8 Unicode", 3},
-	{CharsetUTF8MB4, CollationUTF8MB4, make(map[string]*Collation), "UTF-8 Unicode", 4},
-	{CharsetASCII, CollationASCII, make(map[string]*Collation), "US ASCII", 1},
-	{CharsetLatin1, CollationLatin1, make(map[string]*Collation), "Latin1", 1},
-	{CharsetBin, CollationBin, make(map[string]*Collation), "binary", 1},
+var charsetInfos = map[string]*Charset{
+	CharsetUTF8:    {CharsetUTF8, CollationUTF8, make(map[string]*Collation), "UTF-8 Unicode", 3},
+	CharsetUTF8MB4: {CharsetUTF8MB4, CollationUTF8MB4, make(map[string]*Collation), "UTF-8 Unicode", 4},
+	CharsetASCII:   {CharsetASCII, CollationASCII, make(map[string]*Collation), "US ASCII", 1},
+	CharsetLatin1:  {CharsetLatin1, CollationLatin1, make(map[string]*Collation), "Latin1", 1},
+	CharsetBin:     {CharsetBin, CollationBin, make(map[string]*Collation), "binary", 1},
+}
+
+// All the experimental supported charset should be in the following table, only used when charset feature is enable.
+var experimentalCharsetInfo = map[string]*Charset{
+	CharsetGBK: {CharsetGBK, CollationGBK, make(map[string]*Collation), "Chinese Internal Code Specification", 4},
 }
 
 // All the names supported collations should be in the following table.
@@ -69,17 +94,20 @@ var supportedCollationNames = map[string]struct{}{
 	CollationBin:     {},
 }
 
-// Desc is a charset description.
-type Desc struct {
-	Name             string
-	Desc             string
-	DefaultCollation string
-	Maxlen           int
-}
-
 // GetSupportedCharsets gets descriptions for all charsets supported so far.
-func GetSupportedCharsets() []*Desc {
-	return descs
+func GetSupportedCharsets() []*Charset {
+	charsets := make([]*Charset, 0, len(charsetInfos))
+	for _, ch := range charsetInfos {
+		charsets = append(charsets, ch)
+	}
+
+	if CharsetFeatEnabled() {
+		for _, ch := range experimentalCharsetInfo {
+			charsets = append(charsets, ch)
+		}
+	}
+
+	return charsets
 }
 
 // GetSupportedCollations gets information for all collations supported so far.
@@ -94,9 +122,8 @@ func ValidCharsetAndCollation(cs string, co string) bool {
 	if cs == "" {
 		cs = "utf8"
 	}
-	cs = strings.ToLower(cs)
-	c, ok := charsets[cs]
-	if !ok {
+	chs, err := GetCharsetInfo(cs)
+	if err != nil {
 		return false
 	}
 
@@ -104,21 +131,17 @@ func ValidCharsetAndCollation(cs string, co string) bool {
 		return true
 	}
 	co = strings.ToLower(co)
-	_, ok = c.Collations[co]
+	_, ok := chs.Collations[co]
 	return ok
 }
 
 // GetDefaultCollation returns the default collation for charset.
 func GetDefaultCollation(charset string) (string, error) {
-	charset = strings.ToLower(charset)
-	if charset == CharsetBin {
-		return CollationBin, nil
+	cs, err := GetCharsetInfo(charset)
+	if err != nil {
+		return "", err
 	}
-	c, ok := charsets[charset]
-	if !ok {
-		return "", errors.Errorf("Unknown charset %s", charset)
-	}
-	return c.DefaultCollation, nil
+	return cs.DefaultCollation, nil
 }
 
 // GetDefaultCharsetAndCollate returns the default charset and collation.
@@ -127,30 +150,16 @@ func GetDefaultCharsetAndCollate() (string, string) {
 }
 
 // GetCharsetInfo returns charset and collation for cs as name.
-func GetCharsetInfo(cs string) (string, string, error) {
-	c, ok := charsets[strings.ToLower(cs)]
-	if !ok {
-		return "", "", errors.Errorf("Unknown charset %s", cs)
+func GetCharsetInfo(cs string) (*Charset, error) {
+	if c, ok := charsetInfos[strings.ToLower(cs)]; ok {
+		return c, nil
 	}
-	return c.Name, c.DefaultCollation, nil
-}
-
-// GetCharsetDesc gets charset descriptions in the local charsets.
-func GetCharsetDesc(cs string) (*Desc, error) {
-	switch strings.ToLower(cs) {
-	case CharsetUTF8:
-		return descs[0], nil
-	case CharsetUTF8MB4:
-		return descs[1], nil
-	case CharsetASCII:
-		return descs[2], nil
-	case CharsetLatin1:
-		return descs[3], nil
-	case CharsetBin:
-		return descs[4], nil
-	default:
-		return nil, errors.Errorf("Unknown charset %s", cs)
+	if CharsetFeatEnabled() {
+		if c, ok := experimentalCharsetInfo[strings.ToLower(cs)]; ok {
+			return c, nil
+		}
 	}
+	return nil, errors.Errorf("Unknown charset %s", cs)
 }
 
 // GetCharsetInfoByID returns charset and collation for id as cs_number.
@@ -208,6 +217,10 @@ const (
 	CharsetLatin1 = "latin1"
 	// CollationLatin1 is the default collation for CharsetLatin1.
 	CollationLatin1 = "latin1_bin"
+	// CharsetGBK represents gbk character encoding.
+	CharsetGBK = "gbk"
+	// CollationGBK is the default collation for CharsetGBK.
+	CollationGBK = "gbk_chinese_ci"
 )
 
 var collations = []*Collation{
@@ -436,17 +449,6 @@ var collations = []*Collation{
 
 // init method always puts to the end of file.
 func init() {
-	for _, c := range charsetInfos {
-		charsets[c.Name] = c
-		desc := &Desc{
-			Name:             c.Name,
-			DefaultCollation: c.DefaultCollation,
-			Desc:             c.Desc,
-			Maxlen:           c.Maxlen,
-		}
-		descs = append(descs, desc)
-	}
-
 	for _, c := range collations {
 		collationsIDMap[c.ID] = c
 		collationsNameMap[c.Name] = c
@@ -455,7 +457,7 @@ func init() {
 			supportedCollations = append(supportedCollations, c)
 		}
 
-		if charset, ok := charsets[c.CharsetName]; ok {
+		if charset, ok := charsetInfos[c.CharsetName]; ok {
 			charset.Collations[c.Name] = c
 		}
 	}

--- a/charset/charset_test.go
+++ b/charset/charset_test.go
@@ -61,10 +61,8 @@ func (s *testCharsetSuite) TestValidCharset(c *C) {
 }
 
 func (s *testCharsetSuite) TestGetSupportedCharsets(c *C) {
-	charset := &Charset{"test", "test_bin", nil, "Test", 5}
-	charsetInfos = append(charsetInfos, charset)
 	descs := GetSupportedCharsets()
-	c.Assert(len(descs), Equals, len(charsetInfos)-1)
+	c.Assert(len(descs), Equals, len(charsetInfos))
 }
 
 func testGetDefaultCollation(c *C, charset string, expectCollation string, succ bool) {
@@ -99,13 +97,13 @@ func (s *testCharsetSuite) TestGetDefaultCollation(c *C) {
 	charset_num := 0
 	for _, collate := range collations {
 		if collate.IsDefault {
-			if desc, ok := charsets[collate.CharsetName]; ok {
+			if desc, ok := charsetInfos[collate.CharsetName]; ok {
 				c.Assert(collate.Name, Equals, desc.DefaultCollation)
 				charset_num += 1
 			}
 		}
 	}
-	c.Assert(charset_num, Equals, len(charsets))
+	c.Assert(charset_num, Equals, len(charsetInfos))
 }
 
 func (s *testCharsetSuite) TestSupportedCollations(c *C) {
@@ -142,7 +140,7 @@ func (s *testCharsetSuite) TestGetCharsetDesc(c *C) {
 		{"", "utf8_bin", false},
 	}
 	for _, tt := range tests {
-		desc, err := GetCharsetDesc(tt.cs)
+		desc, err := GetCharsetInfo(tt.cs)
 		if !tt.succ {
 			c.Assert(err, NotNil)
 		} else {
@@ -170,6 +168,6 @@ func BenchmarkGetCharsetDesc(b *testing.B) {
 	cs := charsets[index]
 
 	for i := 0; i < b.N; i++ {
-		GetCharsetDesc(cs)
+		GetCharsetInfo(cs)
 	}
 }

--- a/charset/charset_test.go
+++ b/charset/charset_test.go
@@ -77,11 +77,6 @@ func (s *testCharsetSuite) TestValidCustomCharset(c *C) {
 	}
 }
 
-func (s *testCharsetSuite) TestGetSupportedCharsets(c *C) {
-	descs := GetSupportedCharsets()
-	c.Assert(len(descs), Equals, len(charsetInfos))
-}
-
 func testGetDefaultCollation(c *C, charset string, expectCollation string, succ bool) {
 	b, err := GetDefaultCollation(charset)
 	if !succ {

--- a/digester.go
+++ b/digester.go
@@ -186,7 +186,7 @@ func (d *sqlDigester) normalize(sql string) {
 
 		if currTok.tok == identifier {
 			if strings.HasPrefix(currTok.lit, "_") {
-				_, _, err := charset.GetCharsetInfo(currTok.lit[1:])
+				_, err := charset.GetCharsetInfo(currTok.lit[1:])
 				if err == nil {
 					currTok.tok = underscoreCS
 					goto APPEND

--- a/misc.go
+++ b/misc.go
@@ -990,10 +990,10 @@ func handleIdent(lval *yySymType) int {
 	if !strings.HasPrefix(s, "_") {
 		return identifier
 	}
-	cs, _, err := charset.GetCharsetInfo(s[1:])
+	cs, err := charset.GetCharsetInfo(s[1:])
 	if err != nil {
 		return identifier
 	}
-	lval.ident = cs
+	lval.ident = cs.Name
 	return underscoreCS
 }

--- a/parser.y
+++ b/parser.y
@@ -9529,14 +9529,14 @@ CharsetName:
 	StringName
 	{
 		// Validate input charset name to keep the same behavior as parser of MySQL.
-		name, _, err := charset.GetCharsetInfo($1)
+		cs, err := charset.GetCharsetInfo($1)
 		if err != nil {
 			yylex.AppendError(ErrUnknownCharacterSet.GenWithStackByArgs($1))
 			return 1
 		}
 		// Use charset name returned from charset.GetCharsetInfo(),
 		// to keep lower case of input for generated column restore.
-		$$ = name
+		$$ = cs.Name
 	}
 |	binaryType
 	{
@@ -11489,14 +11489,14 @@ OptCharsetWithOptBinary:
 	}
 |	"UNICODE"
 	{
-		name, _, err := charset.GetCharsetInfo("ucs2")
+		cs, err := charset.GetCharsetInfo("ucs2")
 		if err != nil {
 			yylex.AppendError(ErrUnknownCharacterSet.GenWithStackByArgs("ucs2"))
 			return 1
 		}
 		$$ = &ast.OptBinary{
 			IsBinary: false,
-			Charset:  name,
+			Charset:  cs.Name,
 		}
 	}
 |	"BYTE"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- use a map to store the charset info directly
- remove `Desc` struct, it is definitely same with `Charset`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change

