### PR TITLE
move placement into not keywords

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -210,7 +210,6 @@ import (
 	over              "OVER"
 	partition         "PARTITION"
 	percentRank       "PERCENT_RANK"
-	placement         "PLACEMENT"
 	precisionType     "PRECISION"
 	primary           "PRIMARY"
 	procedure         "PROCEDURE"
@@ -661,6 +660,7 @@ import (
 	max                   "MAX"
 	now                   "NOW"
 	optRuleBlacklist      "OPT_RULE_BLACKLIST"
+	placement             "PLACEMENT"
 	plan                  "PLAN"
 	position              "POSITION"
 	primaryRegion         "PRIMARY_REGION"
@@ -1388,6 +1388,7 @@ import (
 
 %precedence empty
 %precedence as
+%precedence placement
 %precedence lowerThanSelectOpt
 %precedence sqlBufferResult
 %precedence sqlBigResult
@@ -2381,6 +2382,7 @@ KeyOrIndexOpt:
 |	KeyOrIndex
 
 ColumnKeywordOpt:
+	/* empty */ %prec empty
 	{}
 |	"COLUMN"
 
@@ -2428,6 +2430,7 @@ PartitionNameList:
 	}
 
 ConstraintKeywordOpt:
+	/* empty */ %prec empty
 	{
 		$$ = nil
 	}
@@ -6124,6 +6127,7 @@ NotKeywordToken:
 |	"RECENT"
 |	"RECREATOR"
 |	"RUNNING"
+|	"PLACEMENT"
 |	"PLAN"
 |	"POSITION"
 |	"S3"

--- a/parser_test.go
+++ b/parser_test.go
@@ -108,7 +108,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"max_connections_per_hour", "max_queries_per_hour", "max_updates_per_hour", "max_user_connections", "event", "reload", "routine", "temporary",
 		"following", "preceding", "unbounded", "respect", "nulls", "current", "last", "against", "expansion",
 		"chain", "error", "general", "nvarchar", "pack_keys", "parser", "shard_row_id_bits", "pre_split_regions",
-		"constraints", "role", "replicas", "policy", "s3", "strict", "running", "stop", "preserve",
+		"constraints", "role", "replicas", "policy", "s3", "strict", "running", "stop", "preserve", "placement",
 	}
 	for _, kw := range unreservedKws {
 		src := fmt.Sprintf("SELECT %s FROM tbl;", kw)


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

`placement` is not a keyword in mysql. Precedence is used to avoid ambiguity.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to be included in the release note
