### PR TITLE
Add 'auth_socket'

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -1211,6 +1211,7 @@ func (n *UserSpec) EncodedPassword() (string, bool) {
 		if len(opt.HashString) != (mysql.PWDHashLen+1) || !strings.HasPrefix(opt.HashString, "*") {
 			return "", false
 		}
+	case mysql.AuthSocket:
 	default:
 		return "", false
 	}

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -166,6 +166,7 @@ const (
 const (
 	AuthNativePassword      = "mysql_native_password"
 	AuthCachingSha2Password = "caching_sha2_password"
+	AuthSocket              = "auth_socket"
 )
 
 // MySQL database and tables.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Add `auth_socket` as authentication method, which is used by https://github.com/pingcap/tidb/pull/27561

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
