### PR TITLE
unit test: added a more precise sysStackPrefix

### DIFF
--- a/terror/terror_test.go
+++ b/terror/terror_test.go
@@ -103,13 +103,15 @@ func (s *testTErrorSuite) TestTraceAndLocation(c *C) {
 	stack := errors.ErrorStack(err)
 	lines := strings.Split(stack, "\n")
 	goroot := strings.ReplaceAll(runtime.GOROOT(), string(os.PathSeparator), "/")
-	var sysStack = 0
+	// Some system may put GOROOT in the same path as GOPATH, so we add a "/src" postfix to better differentiate sysStack
+	sysStackPrefix := goroot + "/src"
+	var sysStackCount = 0
 	for _, line := range lines {
-		if strings.Contains(line, goroot) {
-			sysStack++
+		if strings.Contains(line, sysStackPrefix) {
+			sysStackCount++
 		}
 	}
-	c.Assert(len(lines)-(2*sysStack), Equals, 15, Commentf("stack =\n%s", stack))
+	c.Assert(len(lines)-(2*sysStackCount), Equals, 15, Commentf("stack =\n%s", stack))
 	var containTerr bool
 	for _, v := range lines {
 		if strings.Contains(v, "terror_test.go") {


### PR DESCRIPTION
Signed-off-by: AmoebaProtozoa <davidyangad@gmail.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

As issue #843 suggest, if a system's GOPATH contains GOROOT,  (For example, if your GOPATH is `$HOME/gopath` and GOHOME is `$HOME/go`, or if they are the same). sysStack's calculation will be off, causing unit test fail.

### What is changed and how it works?

For better identify system stack, a postfix of `"/src"` is added to the system stack prefix.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit Test
- Manual Test