### PR TITLE
settings: Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @pingcap/co-parser


### PR DESCRIPTION
We don't use CODEOWNERS, also the information is incorrect.