### PR TITLE
mysql: add customized release version config option

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -30,9 +30,18 @@ var (
 	// TiDBReleaseVersion is initialized by (git describe --tags) in Makefile.
 	TiDBReleaseVersion = "None"
 
+	// CustomizedReleaseVersion is initialized by (your definition) in Makefile.
+	CustomizedReleaseVersion = "None"
+
 	// ServerVersion is the version information of this tidb-server in MySQL's format.
-	ServerVersion = fmt.Sprintf("5.7.25-TiDB-%s", TiDBReleaseVersion)
+	ServerVersion = fmt.Sprintf("5.7.25-%s", CustomizedReleaseVersion)
 )
+
+func init() {
+	if CustomizedReleaseVersion == "None" {
+		ServerVersion = fmt.Sprintf("5.7.25-TiDB-%s", TiDBReleaseVersion)
+	}
+}
 
 // Header information.
 const (

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -34,12 +34,12 @@ var (
 	CustomizedReleaseVersion = "None"
 
 	// ServerVersion is the version information of this tidb-server in MySQL's format.
-	ServerVersion = fmt.Sprintf("5.7.25-%s", CustomizedReleaseVersion)
+	ServerVersion = fmt.Sprintf("5.7.25-TiDB-%s", TiDBReleaseVersion)
 )
 
 func init() {
-	if CustomizedReleaseVersion == "None" {
-		ServerVersion = fmt.Sprintf("5.7.25-TiDB-%s", TiDBReleaseVersion)
+	if CustomizedReleaseVersion != "None" {
+		ServerVersion = fmt.Sprintf("5.7.25-%s", CustomizedReleaseVersion)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: ailinkid <314806019@qq.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add customized release version config option which will be initialized in the TiDB makefile.

### What is changed and how it works?
Add customized release version config option which will be initialized in the TiDB makefile.
Related-TiDB-PR https://github.com/pingcap/tidb/pull/27692

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch
