### PR TITLE
parser: move policyinfo test from tidb to parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63
 	github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
+	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.18.1
 	golang.org/x/text v0.3.6
 )

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -16,6 +16,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
@@ -404,4 +405,38 @@ func (testModelSuite) TestDefaultValue(c *C) {
 			c.Assert(col.OriginDefaultValue == newCol.OriginDefaultValue, IsFalse, cmt)
 		}
 	}
+}
+
+func TestPlacementSettingsString(t *testing.T) {
+	assert := assert.New(t)
+
+	settings := &PlacementSettings{
+		PrimaryRegion: "us-east-1",
+		Regions:       "us-east-1,us-east-2",
+		Schedule:      "EVEN",
+	}
+	assert.Equal("PRIMARY_REGION=\"us-east-1\" REGIONS=\"us-east-1,us-east-2\" SCHEDULE=\"EVEN\"", settings.String())
+
+	settings = &PlacementSettings{
+		LeaderConstraints: "[+region=bj]",
+	}
+	assert.Equal("LEADER_CONSTRAINTS=\"[+region=bj]\"", settings.String())
+
+	settings = &PlacementSettings{
+		Voters:              1,
+		VoterConstraints:    "[+region=us-east-1]",
+		Followers:           2,
+		FollowerConstraints: "[+disk=ssd]",
+		Learners:            3,
+		LearnerConstraints:  "[+region=us-east-2]",
+	}
+	assert.Equal("VOTERS=1 VOTER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=2 FOLLOWER_CONSTRAINTS=\"[+disk=ssd]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=us-east-2]\"", settings.String())
+
+	settings = &PlacementSettings{
+		Voters:      3,
+		Followers:   2,
+		Learners:    1,
+		Constraints: "{+us-east-1:1,+us-east-2:1}",
+	}
+	assert.Equal("CONSTRAINTS=\"{+us-east-1:1,+us-east-2:1}\" VOTERS=3 FOLLOWERS=2 LEARNERS=1", settings.String())
 }

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -16,13 +16,13 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestT(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: ailinkid <314806019@qq.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In https://github.com/pingcap/parser/pull/1327 we move policyInfo into parser but the related test case.
So this pr move the missed policyInfo test from TiDB repo to Parser repo

### What is changed and how it works?
move some tests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
