### PR TITLE
introduce a new Restore Flag RestoreBracketAroundBinaryOperation

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -173,6 +173,9 @@ func restoreBinaryOpWithSpacesAround(ctx *format.RestoreCtx, op opcode.Op) error
 
 // Restore implements Node interface.
 func (n *BinaryOperationExpr) Restore(ctx *format.RestoreCtx) error {
+	if ctx.Flags.HasRestoreBracketAroundBinaryOperation() {
+		ctx.WritePlain("(")
+	}
 	if err := n.L.Restore(ctx); err != nil {
 		return errors.Annotate(err, "An error occurred when restore BinaryOperationExpr.L")
 	}
@@ -182,7 +185,9 @@ func (n *BinaryOperationExpr) Restore(ctx *format.RestoreCtx) error {
 	if err := n.R.Restore(ctx); err != nil {
 		return errors.Annotate(err, "An error occurred when restore BinaryOperationExpr.R")
 	}
-
+	if ctx.Flags.HasRestoreBracketAroundBinaryOperation() {
+		ctx.WritePlain(")")
+	}
 	return nil
 }
 

--- a/format/format.go
+++ b/format/format.go
@@ -218,6 +218,7 @@ const (
 	RestoreNameBackQuotes
 
 	RestoreSpacesAroundBinaryOperation
+	RestoreBracketAroundBinaryOperation
 
 	RestoreStringWithoutCharset
 	RestoreStringWithoutDefaultCharset
@@ -281,6 +282,10 @@ func (rf RestoreFlags) HasNameBackQuotesFlag() bool {
 // HasSpacesAroundBinaryOperationFlag returns a boolean indicating whether `rf` has `RestoreSpacesAroundBinaryOperation` flag.
 func (rf RestoreFlags) HasSpacesAroundBinaryOperationFlag() bool {
 	return rf.has(RestoreSpacesAroundBinaryOperation)
+}
+
+func (rf RestoreFlags) HasRestoreBracketAroundBinaryOperation() bool {
+	return rf.has(RestoreBracketAroundBinaryOperation)
 }
 
 func (rf RestoreFlags) HasStringWithoutDefaultCharset() bool {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
To fix https://github.com/pingcap/tidb/issues/27544.
Now when restoring an expression, the parser doesn't add brackets for binary operations, which may change the meaning of the expression after restoring.
For example, `mod( year(a) - abs(weekday(a) + dayofweek(a)), 4) + 1` will be restored to `YEAR(a)-ABS(WEEKDAY(a)+DAYOFWEEK(a))%4+1`.


### What is changed and how it works?
Introduce a new restore flag RestoreBracketAroundBinaryOperation to control this behavior.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test