### PR TITLE
*: support select for update of tables

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -1063,6 +1063,7 @@ import (
 	OnDuplicateKeyUpdate                   "ON DUPLICATE KEY UPDATE value list"
 	OnCommitOpt                            "ON COMMIT DELETE |PRESERVE ROWS"
 	DuplicateOpt                           "[IGNORE|REPLACE] in CREATE TABLE ... SELECT statement or LOAD DATA statement"
+	OfTablesOpt                            "OF table_name [, ...]"
 	OptErrors                              "ERRORS or empty"
 	OptFull                                "Full or empty"
 	OptTemporary                           "TEMPORARY or empty"
@@ -9175,40 +9176,72 @@ SelectLockOpt:
 	{
 		$$ = nil
 	}
-|	"FOR" "UPDATE"
+|	"FOR" "UPDATE" OfTablesOpt
 	{
-		$$ = &ast.SelectLockInfo{LockType: ast.SelectLockForUpdate}
+		$$ = &ast.SelectLockInfo{
+			LockType: ast.SelectLockForUpdate,
+			Tables:   $3.([]*ast.TableName),
+		}
 	}
-|	"FOR" "SHARE"
+|	"FOR" "SHARE" OfTablesOpt
 	{
-		$$ = &ast.SelectLockInfo{LockType: ast.SelectLockForShare}
+		$$ = &ast.SelectLockInfo{
+			LockType: ast.SelectLockForShare,
+			Tables:   $3.([]*ast.TableName),
+		}
 	}
-|	"FOR" "UPDATE" "NOWAIT"
+|	"FOR" "UPDATE" OfTablesOpt "NOWAIT"
 	{
-		$$ = &ast.SelectLockInfo{LockType: ast.SelectLockForUpdateNoWait}
+		$$ = &ast.SelectLockInfo{
+			LockType: ast.SelectLockForUpdateNoWait,
+			Tables:   $3.([]*ast.TableName),
+		}
 	}
-|	"FOR" "UPDATE" "WAIT" NUM
+|	"FOR" "UPDATE" OfTablesOpt "WAIT" NUM
 	{
 		$$ = &ast.SelectLockInfo{
 			LockType: ast.SelectLockForUpdateWaitN,
-			WaitSec:  getUint64FromNUM($4),
+			WaitSec:  getUint64FromNUM($5),
+			Tables:   $3.([]*ast.TableName),
 		}
 	}
-|	"FOR" "SHARE" "NOWAIT"
+|	"FOR" "SHARE" OfTablesOpt "NOWAIT"
 	{
-		$$ = &ast.SelectLockInfo{LockType: ast.SelectLockForShareNoWait}
+		$$ = &ast.SelectLockInfo{
+			LockType: ast.SelectLockForShareNoWait,
+			Tables:   $3.([]*ast.TableName),
+		}
 	}
-|	"FOR" "UPDATE" "SKIP" "LOCKED"
+|	"FOR" "UPDATE" OfTablesOpt "SKIP" "LOCKED"
 	{
-		$$ = &ast.SelectLockInfo{LockType: ast.SelectLockForUpdateSkipLocked}
+		$$ = &ast.SelectLockInfo{
+			LockType: ast.SelectLockForUpdateSkipLocked,
+			Tables:   $3.([]*ast.TableName),
+		}
 	}
-|	"FOR" "SHARE" "SKIP" "LOCKED"
+|	"FOR" "SHARE" OfTablesOpt "SKIP" "LOCKED"
 	{
-		$$ = &ast.SelectLockInfo{LockType: ast.SelectLockForShareSkipLocked}
+		$$ = &ast.SelectLockInfo{
+			LockType: ast.SelectLockForShareSkipLocked,
+			Tables:   $3.([]*ast.TableName),
+		}
 	}
 |	"LOCK" "IN" "SHARE" "MODE"
 	{
-		$$ = &ast.SelectLockInfo{LockType: ast.SelectLockForShare}
+		$$ = &ast.SelectLockInfo{
+			LockType: ast.SelectLockForShare,
+			Tables:   []*ast.TableName{},
+		}
+	}
+
+OfTablesOpt:
+	/* empty */
+	{
+		$$ = []*ast.TableName{}
+	}
+|	"OF" TableNameList
+	{
+		$$ = $2.([]*ast.TableName)
 	}
 
 SetOprStmt:

--- a/parser_test.go
+++ b/parser_test.go
@@ -680,6 +680,15 @@ func (s *testParserSuite) TestDMLStmt(c *C) {
 		{"select * from t lock in share mode nowait", false, ""},
 		{"select * from t lock in share mode skip locked", false, ""},
 
+		{"select * from t for update of t", true, "SELECT * FROM `t` FOR UPDATE OF `t`"},
+		{"select * from t for share of t", true, "SELECT * FROM `t` FOR SHARE OF `t`"},
+		{"select * from t for update of t nowait", true, "SELECT * FROM `t` FOR UPDATE OF `t` NOWAIT"},
+		{"select * from t for update of t wait 5", true, "SELECT * FROM `t` FOR UPDATE OF `t` WAIT 5"},
+		{"select * from t limit 1 for update of t wait 11", true, "SELECT * FROM `t` LIMIT 1 FOR UPDATE OF `t` WAIT 11"},
+		{"select * from t for share of t nowait", true, "SELECT * FROM `t` FOR SHARE OF `t` NOWAIT"},
+		{"select * from t for update of t skip locked", true, "SELECT * FROM `t` FOR UPDATE OF `t` SKIP LOCKED"},
+		{"select * from t for share of t skip locked", true, "SELECT * FROM `t` FOR SHARE OF `t` SKIP LOCKED"},
+
 		// select into outfile
 		{"select a, b from t into outfile '/tmp/result.txt'", true, "SELECT `a`,`b` FROM `t` INTO OUTFILE '/tmp/result.txt'"},
 		{"select a from t order by a into outfile '/tmp/abc'", true, "SELECT `a` FROM `t` ORDER BY `a` INTO OUTFILE '/tmp/abc'"},


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
For a multi-table join, a for update stmt locks all tables, some tables may only be read-only tables that participate in it.


### What is changed and how it works?
Supports the of tables syntax, which specifies that only some of the tables are locked.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
