### PR TITLE
parser: support 'binary' symbol in set statements

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -9645,6 +9645,10 @@ SetExpr:
 	{
 		$$ = ast.NewValueExpr("ON", parser.charset, parser.collation)
 	}
+|	"BINARY"
+	{
+		$$ = ast.NewValueExpr("BINARY", parser.charset, parser.collation)
+	}
 |	ExprOrDefault
 
 EqOrAssignmentEq:

--- a/parser_test.go
+++ b/parser_test.go
@@ -1179,6 +1179,8 @@ func (s *testParserSuite) TestDBAStmt(c *C) {
 		// set default value
 		{"SET @@global.autocommit = default", true, "SET @@GLOBAL.`autocommit`=DEFAULT"},
 		{"SET @@session.autocommit = default", true, "SET @@SESSION.`autocommit`=DEFAULT"},
+		// set binary value
+		{"SET @@character_set_results = binary", true, "SET @@SESSION.`character_set_results`=_UTF8MB4'BINARY'"},
 		// SET CHARACTER SET
 		{"SET CHARACTER SET utf8mb4;", true, "SET CHARSET 'utf8mb4'"},
 		{"SET CHARACTER SET 'utf8mb4';", true, "SET CHARSET 'utf8mb4'"},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Using `BINARY` in SET statements gets a syntax error because it is a keyword.

```sql
mysql> set @@character_set_results = binary;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 36 near ""
```

MySQL handled this problem by adding a rule:

https://github.com/mysql/mysql-server/blob/beb865a960b9a8a16cf999c323e46c5b0c67f21f/sql/sql_yacc.yy#L15902

### What is changed and how it works?

Add a rule for `SetExpr`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

NA

Side effects

NA

Related changes

NA
