### PR TITLE
grant `create routine`,`alter routine`,`event`,`trigger` on db.*.  fix

### DIFF
--- a/mysql/privs.go
+++ b/mysql/privs.go
@@ -65,6 +65,10 @@ var Priv2SetStr = map[PrivilegeType]string{
 	GrantPriv:      "Grant",
 	ReferencesPriv: "References",
 	LockTablesPriv: "Lock Tables",
+	CreateRoutinePriv: "Create Routine",
+	AlterRoutinePriv: "Alter Routine",
+	EventPriv: "Event",
+	TriggerPriv: "Trigger",
 	AlterPriv:      "Alter",
 	ExecutePriv:    "Execute",
 	IndexPriv:      "Index",
@@ -86,6 +90,9 @@ var SetStr2Priv = map[string]PrivilegeType{
 	"Grant":       GrantPriv,
 	"References":  ReferencesPriv,
 	"Lock Tables": LockTablesPriv,
+	"Create Routine": CreateRoutinePriv,
+	"Alter Routine": AlterRoutinePriv,
+	"Trigger": TriggerPriv,
 	"Alter":       AlterPriv,
 	"Execute":     ExecutePriv,
 	"Index":       IndexPriv,
@@ -304,7 +311,7 @@ var AllGlobalPrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv, DeletePriv, 
 var AllDBPrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv, DeletePriv, CreatePriv, DropPriv, ReferencesPriv, LockTablesPriv, CreateRoutinePriv, AlterRoutinePriv, AlterPriv, ExecutePriv, IndexPriv, EventPriv, TriggerPriv, CreateViewPriv, ShowViewPriv}
 
 // AllTablePrivs is all the privileges in table scope.
-var AllTablePrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv, DeletePriv, CreatePriv, DropPriv, IndexPriv, TriggerPriv, ReferencesPriv, AlterPriv, CreateViewPriv, ShowViewPriv}
+var AllTablePrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv, DeletePriv, CreatePriv, DropPriv, IndexPriv, ReferencesPriv, TriggerPriv, AlterPriv, CreateViewPriv, ShowViewPriv}
 
 // AllColumnPrivs is all the privileges in column scope.
 var AllColumnPrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv}

--- a/mysql/privs.go
+++ b/mysql/privs.go
@@ -223,7 +223,7 @@ const (
 	SuperPriv
 	// CreateUserPriv is the privilege to create user.
 	CreateUserPriv
-	// TriggerPriv is not checked yet.
+	// TriggerPriv is privilege to create, drop, execute, or display triggers for tables.
 	TriggerPriv
 	// DropPriv is the privilege to drop schema/table.
 	DropPriv
@@ -301,10 +301,10 @@ func (privs Privileges) Has(p PrivilegeType) bool {
 var AllGlobalPrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv, DeletePriv, CreatePriv, DropPriv, ProcessPriv, ReferencesPriv, AlterPriv, ShowDBPriv, SuperPriv, ExecutePriv, IndexPriv, CreateUserPriv, CreateTablespacePriv, TriggerPriv, CreateViewPriv, ShowViewPriv, CreateRolePriv, DropRolePriv, CreateTMPTablePriv, LockTablesPriv, CreateRoutinePriv, AlterRoutinePriv, EventPriv, ShutdownPriv, ReloadPriv, FilePriv, ConfigPriv, ReplicationClientPriv, ReplicationSlavePriv}
 
 // AllDBPrivs is all the privileges in database scope.
-var AllDBPrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv, DeletePriv, CreatePriv, DropPriv, ReferencesPriv, LockTablesPriv, AlterPriv, ExecutePriv, IndexPriv, CreateViewPriv, ShowViewPriv}
+var AllDBPrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv, DeletePriv, CreatePriv, DropPriv, ReferencesPriv, LockTablesPriv, CreateRoutinePriv, AlterRoutinePriv, AlterPriv, ExecutePriv, IndexPriv, EventPriv, TriggerPriv, CreateViewPriv, ShowViewPriv}
 
 // AllTablePrivs is all the privileges in table scope.
-var AllTablePrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv, DeletePriv, CreatePriv, DropPriv, IndexPriv, ReferencesPriv, AlterPriv, CreateViewPriv, ShowViewPriv}
+var AllTablePrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv, DeletePriv, CreatePriv, DropPriv, IndexPriv, TriggerPriv, ReferencesPriv, AlterPriv, CreateViewPriv, ShowViewPriv}
 
 // AllColumnPrivs is all the privileges in column scope.
 var AllColumnPrivs = Privileges{SelectPriv, InsertPriv, UpdatePriv}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Parser related fix for https://github.com/pingcap/tidb/issues/27955 (`create routine`, `alter routine`,`event`,`trigger`need to be on DB level).

### What is changed and how it works?
In MySQL, `CREATE ROUTINE`,`ALTER ROUTINE`,`EVENT`,`TRIGGER` these privileges shoule be on DB level, and `TRIGGER` should be in table level,the Parser definition `AllDBPrivs` did not include `CREATE ROUTINE`,`ALTER ROUTINE`,`EVENT`,`TRIGGER` and  `AllTablePrivs` did not include `TRIGGER` which made TiDB fail when checking it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   - Built TiDB with `go.mod` change `replace github.com/pingcap/parser => ../parser` to build tidb-server with the locally changed parser repository
   - Tested this
       ```
       CREATE USER u;
       CREATE DATABASE t;
       USE t;
       CREATE TABLE t1 (a int);
       GRANT create routine  ON t.* TO u;
       GRANT alter routine ON t.* TO u;
       GRANT event ON t.* TO u;
       GRANT trigger ON t.* TO u;
       GRANT trigger ON t.t1 TO u;
      ```
  successful

Code changes

 - Has exported variable/fields change: `AllDBPrivs` , `AllTablePrivs`
