### PR TITLE
charset: fix Encoding.Encode() and add some tests

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -3259,6 +3259,7 @@ var (
 	ErrSystemVersioningWrongPartitions      = terror.ClassDDL.NewStd(mysql.ErrSystemVersioningWrongPartitions)
 	ErrTooManyValues                        = terror.ClassDDL.NewStd(mysql.ErrTooManyValues)
 	ErrWrongPartitionTypeExpectedSystemTime = terror.ClassDDL.NewStd(mysql.ErrWrongPartitionTypeExpectedSystemTime)
+	ErrUnknownCharacterSet                  = terror.ClassDDL.NewStd(mysql.ErrUnknownCharacterSet)
 )
 
 type SubPartitionDefinition struct {

--- a/charset/encoding.go
+++ b/charset/encoding.go
@@ -14,17 +14,19 @@
 package charset
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/cznic/mathutil"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/parser/terror"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/transform"
 )
 
-const (
-	encodingBufferSizeRecycleThreshold = 4 * 1024
+const encodingLegacy = "utf-8" // utf-8 encoding is compatible with old default behavior.
 
-	encodingLegacy = "utf-8" // utf-8 encoding is compatible with old default behavior.
-)
+var errInvalidCharacterString = terror.ClassParser.NewStd(mysql.ErrInvalidCharacterString)
 
 type EncodingLabel string
 
@@ -43,7 +45,6 @@ type Encoding struct {
 	enc        encoding.Encoding
 	name       string
 	charLength func([]byte) int
-	buffer     []byte
 }
 
 // Enabled indicates whether the non-utf8 encoding is used.
@@ -57,11 +58,11 @@ func (e *Encoding) Name() string {
 }
 
 // NewEncoding creates a new Encoding.
-func NewEncoding(label EncodingLabel) *Encoding {
+func NewEncoding(label string) *Encoding {
 	if len(label) == 0 {
 		return &Encoding{}
 	}
-	e, name := lookup(label)
+	e, name := Lookup(label)
 	if e != nil && name != encodingLegacy {
 		return &Encoding{
 			enc:        e,
@@ -72,7 +73,7 @@ func NewEncoding(label EncodingLabel) *Encoding {
 	return &Encoding{name: name}
 }
 
-// UpdateEncoding updates to a new Encoding without changing the buffer.
+// UpdateEncoding updates to a new Encoding.
 func (e *Encoding) UpdateEncoding(label EncodingLabel) {
 	enc, name := lookup(label)
 	e.name = name
@@ -86,59 +87,59 @@ func (e *Encoding) UpdateEncoding(label EncodingLabel) {
 }
 
 // Encode encodes the bytes to a string.
-func (e *Encoding) Encode(src []byte) (string, bool) {
-	return e.transform(e.enc.NewEncoder(), src, false)
+func (e *Encoding) Encode(dest, src []byte) ([]byte, error) {
+	return e.transform(e.enc.NewEncoder(), dest, src, false)
 }
 
-// Decode decodes the bytes to a string.
-func (e *Encoding) Decode(src []byte) (string, bool) {
-	return e.transform(e.enc.NewDecoder(), src, true)
+// Decode decodes the bytes to a string. Please copy the result after calling this.
+func (e *Encoding) Decode(dest, src []byte) ([]byte, error) {
+	return e.transform(e.enc.NewDecoder(), dest, src, true)
 }
 
-func (e *Encoding) transform(transformer transform.Transformer, src []byte, isDecoding bool) (string, bool) {
-	if len(e.buffer) < len(src) {
-		e.buffer = make([]byte, len(src)*2)
+func (e *Encoding) transform(transformer transform.Transformer, dest, src []byte, isDecoding bool) ([]byte, error) {
+	if len(dest) < len(src) {
+		dest = make([]byte, len(src)*2)
 	}
 	var destOffset, srcOffset int
-	ok := true
+	var encodingErr error
 	for {
-		srcEnd := len(src)
+		srcEnd, nextLen := len(src), 1
 		if isDecoding {
-			srcEnd = e.nextCharacterOffset(src, srcOffset)
+			if e.charLength != nil {
+				nextLen = e.charLength(src[srcOffset:])
+			}
+			srcEnd = srcOffset + nextLen
+			if srcEnd > len(src) {
+				srcEnd = len(src)
+			}
 		}
-		nDest, nSrc, err := transformer.Transform(e.buffer[destOffset:], src[srcOffset:srcEnd], false)
+		nDest, nSrc, err := transformer.Transform(dest[destOffset:], src[srcOffset:srcEnd], false)
+		if err == transform.ErrShortDst {
+			// The destination buffer is too small. Enlarge the capacity.
+			newDest := make([]byte, len(dest)*2)
+			copy(newDest, dest)
+			dest = newDest
+		} else if err != nil || isDecoding && e.startWithReplacementChar(dest[destOffset:destOffset+nDest]) {
+			if encodingErr == nil {
+				cutEnd := mathutil.Min(srcOffset+nextLen, len(src))
+				invalidBytes := fmt.Sprintf("%X", string(src[srcOffset:cutEnd]))
+				encodingErr = errInvalidCharacterString.GenWithStackByArgs(e.name, invalidBytes)
+			}
+			// Append '?' to the destination buffer.
+			dest[destOffset] = byte('?')
+			nDest = 1
+			nSrc = nextLen // skip the source bytes that cannot be decoded normally.
+		}
 		destOffset += nDest
 		srcOffset += nSrc
-		if err == nil {
-			if srcOffset >= len(src) {
-				result := string(e.buffer[:destOffset])
-				if len(e.buffer) > encodingBufferSizeRecycleThreshold {
-					// This prevents Encoding from holding too much memory.
-					e.buffer = nil
-				}
-				return result, ok
-			}
-		} else if err == transform.ErrShortDst {
-			newDest := make([]byte, len(e.buffer)*2)
-			copy(newDest, e.buffer)
-			e.buffer = newDest
-		} else {
-			e.buffer[destOffset] = byte('?')
-			destOffset += 1
-			srcOffset += 1
-			ok = false
+		// The source bytes are exhausted.
+		if srcOffset >= len(src) {
+			return dest[:destOffset], encodingErr
 		}
 	}
 }
 
-func (e *Encoding) nextCharacterOffset(src []byte, srcOffset int) int {
-	nextLen := 4
-	if e.charLength != nil {
-		nextLen = e.charLength(src[srcOffset:])
-	}
-	srcEnd := srcOffset + nextLen
-	if srcEnd > len(src) {
-		srcEnd = len(src)
-	}
-	return srcEnd
+// startWithReplacementChar indicates the first bytes are 0xEFBFBD.
+func (e *Encoding) startWithReplacementChar(dst []byte) bool {
+	return len(dst) >= 3 && dst[0] == 0xEF && dst[1] == 0xBF && dst[2] == 0xBD
 }

--- a/charset/encoding.go
+++ b/charset/encoding.go
@@ -87,12 +87,12 @@ func (e *Encoding) UpdateEncoding(label EncodingLabel) {
 	}
 }
 
-// Encode encodes the bytes to a string.
+// Encode convert bytes from utf-8 charset to a specific charset.
 func (e *Encoding) Encode(dest, src []byte) ([]byte, error) {
 	return e.transform(e.enc.NewEncoder(), dest, src, false)
 }
 
-// Decode decodes the bytes to a string.
+// Decode convert bytes from a specific charset to utf-8 charset.
 func (e *Encoding) Decode(dest, src []byte) ([]byte, error) {
 	return e.transform(e.enc.NewDecoder(), dest, src, true)
 }
@@ -144,6 +144,7 @@ func (e *Encoding) generateErr(srcRest []byte, srcNextLen int) error {
 	return errInvalidCharacterString.GenWithStackByArgs(e.name, invalidBytes)
 }
 
+// replacementBytes are bytes for the replacement rune 0xfffd.
 var replacementBytes = []byte{0xEF, 0xBF, 0xBD}
 
 // beginWithReplacementChar check if dst has the prefix '0xEFBFBD'.

--- a/charset/encoding_table.go
+++ b/charset/encoding_table.go
@@ -290,4 +290,7 @@ var encodingNextCharacterLength = map[string]func([]byte) int{
 		}
 		return 4
 	},
+	"binary": func(bs []byte) int {
+		return 1
+	},
 }

--- a/charset/encoding_test.go
+++ b/charset/encoding_test.go
@@ -1,0 +1,58 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package charset_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/charset"
+	"golang.org/x/text/transform"
+)
+
+var _ = Suite(&testEncodingSuite{})
+
+type testEncodingSuite struct {
+}
+
+func (s *testEncodingSuite) TestEncoding(c *C) {
+	enc := charset.NewEncoding("gbk")
+	c.Assert(enc.Name(), Equals, "gbk")
+	c.Assert(enc.Enabled(), IsTrue)
+	enc.UpdateEncoding("utf-8")
+	c.Assert(enc.Name(), Equals, "utf-8")
+	enc.UpdateEncoding("gbk")
+	c.Assert(enc.Name(), Equals, "gbk")
+	c.Assert(enc.Enabled(), IsTrue)
+
+	txt := "一二三四"
+	e, _ := charset.Lookup("gbk")
+	gbkEncodedTxt, _, err := transform.String(e.NewEncoder(), txt)
+	c.Assert(err, IsNil)
+	result, ok := enc.Decode([]byte(gbkEncodedTxt))
+	c.Assert(ok, IsTrue)
+	c.Assert(result, Equals, txt)
+
+	gbkEncodedTxt2, ok := enc.Encode([]byte(txt))
+	c.Assert(ok, IsTrue)
+	c.Assert(gbkEncodedTxt, Equals, gbkEncodedTxt2)
+	result, ok = enc.Decode([]byte(gbkEncodedTxt2))
+	c.Assert(ok, IsTrue)
+	c.Assert(result, Equals, txt)
+
+	invalidGBK := []byte{0xE4, 0xB8, 0x80, 0xE4, 0xBA, 0x8C, 0xE4, 0xB8, 0x89}
+	result, ok = enc.Decode(invalidGBK)
+	c.Assert(ok, IsFalse)
+	// MySQL reports "涓?簩涓" and throws a warning "Invalid gbk character string: '80E4BA'"
+	// However, in GBK decoder provided by 'golang.org/x/text', '0x80' is decoded to '€' normally.
+	c.Assert(result, Equals, "涓€?簩涓?")
+}

--- a/lexer.go
+++ b/lexer.go
@@ -147,12 +147,12 @@ func (s *Scanner) tryDecodeToUTF8String(sql string) string {
 		}
 		return sql
 	}
-	utf8Lit, ok := s.encoding.Decode(Slice(sql))
-	if !ok {
-		s.AppendError(errors.Errorf("Cannot convert string '%x' from %s to utf8mb4", sql, s.encoding.Name()))
+	utf8Lit, err := s.encoding.Decode(nil, Slice(sql))
+	if err != nil {
+		s.AppendError(err)
 		s.lastErrorAsWarn()
 	}
-	return utf8Lit
+	return string(utf8Lit)
 }
 
 func (s *Scanner) getNextToken() int {

--- a/parser.y
+++ b/parser.y
@@ -6455,7 +6455,7 @@ Literal:
 		// See https://dev.mysql.com/doc/refman/5.7/en/charset-literal.html
 		co, err := charset.GetDefaultCollationLegacy($1)
 		if err != nil {
-			yylex.AppendError(yylex.Errorf("Get collation error for charset: %s", $1))
+			yylex.AppendError(ast.ErrUnknownCharacterSet.GenWithStack("Unsupported character introducer: '%-.64s'", $1))
 			return 1
 		}
 		expr := ast.NewValueExpr($2, parser.charset, parser.collation)
@@ -6479,7 +6479,7 @@ Literal:
 	{
 		co, err := charset.GetDefaultCollationLegacy($1)
 		if err != nil {
-			yylex.AppendError(yylex.Errorf("Get collation error for charset: %s", $1))
+			yylex.AppendError(ast.ErrUnknownCharacterSet.GenWithStack("Unsupported character introducer: '%-.64s'", $1))
 			return 1
 		}
 		expr := ast.NewValueExpr($2, parser.charset, parser.collation)
@@ -6495,7 +6495,7 @@ Literal:
 	{
 		co, err := charset.GetDefaultCollationLegacy($1)
 		if err != nil {
-			yylex.AppendError(yylex.Errorf("Get collation error for charset: %s", $1))
+			yylex.AppendError(ast.ErrUnknownCharacterSet.GenWithStack("Unsupported character introducer: '%-.64s'", $1))
 			return 1
 		}
 		expr := ast.NewValueExpr($2, parser.charset, parser.collation)

--- a/parser_test.go
+++ b/parser_test.go
@@ -6330,6 +6330,32 @@ func (s *testParserSuite) TestPlanRecreator(c *C) {
 	c.Assert(v.Analyze, IsTrue)
 }
 
+func (s *testParserSuite) TestCharsetIntroducer(c *C) {
+	p := parser.New()
+	// `_gbk` is treated as an identifier.
+	_, _, err := p.Parse("select _gbk 'a';", "", "")
+	c.Assert(err, IsNil)
+
+	charset.AddCharset(&charset.Charset{
+		Name:             "gbk",
+		DefaultCollation: "gbk_bin",
+		Collations:       map[string]*charset.Collation{},
+		Desc:             "gbk",
+		Maxlen:           2,
+	})
+	defer charset.RemoveCharset("gbk")
+	// `_gbk` is treated as a character set.
+	_, _, err = p.Parse("select _gbk 'a';", "", "")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:1115]Unsupported character introducer: 'gbk'")
+	_, _, err = p.Parse("select _gbk 0x1234;", "", "")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:1115]Unsupported character introducer: 'gbk'")
+	_, _, err = p.Parse("select _gbk 0b101001;", "", "")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:1115]Unsupported character introducer: 'gbk'")
+}
+
 func (s *testParserSuite) TestGBKEncoding(c *C) {
 	p := parser.New()
 	gbkEncoding, _ := charset.Lookup("gbk")

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -134,7 +134,7 @@ func (parser *Parser) SetParserConfig(config ParserConfig) {
 	parser.EnableWindowFunc(config.EnableWindowFunction)
 	parser.SetStrictDoubleTypeCheck(config.EnableStrictDoubleTypeCheck)
 	parser.lexer.skipPositionRecording = config.SkipPositionRecording
-	parser.lexer.encoding = *charset.NewEncoding(charset.Format(config.CharsetClient))
+	parser.lexer.encoding = *charset.NewEncoding(config.CharsetClient)
 }
 
 // Parse parses a query string to raw ast.StmtNode.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Required by https://github.com/pingcap/tidb/pull/27875

### What is changed and how it works?

- Make `FindNextCharacterLength` only be used in the decoding process.
- Add some test for `Encoding`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

NA

Side effects

NA

Related changes

NA
