### PR TITLE
mysql: fix MaxDurationWidthWithFsp

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -212,7 +212,7 @@ const (
 	MaxDatetimeWidthWithFsp  = 26 // YYYY-MM-DD HH:MM:SS[.fraction]
 	MaxDatetimeFullWidth     = 29 // YYYY-MM-DD HH:MM:SS.###### AM
 	MaxDurationWidthNoFsp    = 10 // HH:MM:SS
-	MaxDurationWidthWithFsp  = 15 // HH:MM:SS[.fraction]
+	MaxDurationWidthWithFsp  = 17 // HH:MM:SS[.fraction] -838:59:59.000000 to 838:59:59.000000
 	MaxBlobWidth             = 16777216
 	MaxBitDisplayWidth       = 64
 	MaxFloatPrecisionLength  = 24


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
MaxDurationWidthWithFsp is wrong.

`time` is from `-838:59:59.000000` to `838:59:59.000000`.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
