### PR TITLE
Expose yySymType.Item

### DIFF
--- a/yy_parser.go
+++ b/yy_parser.go
@@ -73,7 +73,11 @@ func NewSymType() SymType {
 }
 
 func (s *SymType) Extract() {
-	s.Item = s.YyType.item
+	if s.YyType.item == nil {
+		s.Item = s.YyType.ident
+	} else {
+	    s.Item = s.YyType.item
+	}
 }
 
 // TrimComment trim comment for special comment code of MySQL.

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -63,6 +63,19 @@ var (
 	specCodeEnd      = regexp.MustCompile(`[ \t]*\*\/$`)
 )
 
+type SymType struct {
+	Item interface{}
+	YyType yySymType
+}
+
+func NewSymType() SymType {
+	return SymType{YyType: yySymType{}}
+}
+
+func (s *SymType) Extract() {
+	s.Item = s.YyType.item
+}
+
 // TrimComment trim comment for special comment code of MySQL.
 func TrimComment(txt string) string {
 	txt = specCodeStart.ReplaceAllString(txt, "")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Expose yySymType to global so that other packages can take advantage of Scanner.Lex() to analyze words. For example, other packages can use Lex() to judge if the string is integer, decimal, etc.

### What is changed and how it works?

Add helper struct SymType and a method to copy the values from yySymType to SymType.
Now code from other packages can call the Lex() in this way.
```go
yySym := parser.NewSymType()
parser.NewScanner("123124").Lex(&yySym.YyType)
yySym.Extract()
fmt.Println(yySym.Item)  // 123124
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
Code changes

No existing function/variables has been changed.

Side effects

None

Related changes

None
