### PR TITLE
support separating auto_increment ID from row ID

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -1968,6 +1968,7 @@ const (
 	TableOptionAutoIdCache
 	TableOptionAutoIncrement
 	TableOptionAutoRandomBase
+	TableOptionRowID
 	TableOptionComment
 	TableOptionAvgRowLength
 	TableOptionCheckSum
@@ -2084,6 +2085,16 @@ func (n *TableOption) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord("DEFAULT COLLATE ")
 		ctx.WritePlain("= ")
 		ctx.WriteKeyWord(n.StrValue)
+	case TableOptionRowID:
+		if n.BoolValue {
+			ctx.WriteWithSpecialComments(tidb.FeatureIDRowID, func() {
+				ctx.WriteKeyWord("FORCE")
+			})
+			ctx.WritePlain(" ")
+		}
+		ctx.WriteKeyWord("ROW_ID ")
+		ctx.WritePlain("= ")
+		ctx.WritePlainf("%d", n.UintValue)
 	case TableOptionAutoIncrement:
 		if n.BoolValue {
 			ctx.WriteWithSpecialComments(tidb.FeatureIDForceAutoInc, func() {

--- a/misc.go
+++ b/misc.go
@@ -599,6 +599,7 @@ var tokenMap = map[string]int{
 	"ROW_COUNT":                rowCount,
 	"ROW_FORMAT":               rowFormat,
 	"ROW":                      row,
+	"ROW_ID":                   rowID,
 	"ROWS":                     rows,
 	"RTREE":                    rtree,
 	"RESUME":                   resume,

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -85,6 +85,7 @@ const (
 	ActionAlterPlacementPolicy          ActionType = 52
 	ActionDropPlacementPolicy           ActionType = 53
 	ActionAlterTablePartitionPolicy     ActionType = 54
+	ActionRebaseRowID                   ActionType = 55
 )
 
 var actionMap = map[ActionType]string{

--- a/model/model.go
+++ b/model/model.go
@@ -259,6 +259,12 @@ const (
 	CurrLatestTableInfoVersion = TableInfoVersion5
 )
 
+// AutoIncrementIDIsSeparated indicates whether auto_increment ID of is separated from _tidb_row_id.
+// For details, see https://github.com/pingcap/tidb/issues/982.
+func AutoIncrementIDIsSeparated(ver uint16) bool {
+	return ver >= TableInfoVersion5
+}
+
 // ExtraHandleName is the name of ExtraHandle Column.
 var ExtraHandleName = NewCIStr("_tidb_rowid")
 

--- a/model/model.go
+++ b/model/model.go
@@ -249,14 +249,14 @@ const (
 	// However, the convert is missed in some scenarios before v2.1.9, so for all those tables prior to TableInfoVersion3, their
 	// charsets / collations will be converted to lower-case while loading from the storage.
 	TableInfoVersion3 = uint16(3)
-	// TableInfoVersion4 indicates that the auto_increment allocator in TiDB has been separated from
+	// TableInfoVersion5 indicates that the auto_increment allocator in TiDB has been separated from
 	// _tidb_rowid allocator. This version is introduced to preserve the compatibility of old tables:
-	// the tables with version < TableInfoVersion4 still use a single allocator for auto_increment and _tidb_rowid.
+	// the tables with version < TableInfoVersion5 still use a single allocator for auto_increment and _tidb_rowid.
 	// Also see https://github.com/pingcap/tidb/issues/982.
-	TableInfoVersion4 = uint16(4)
+	TableInfoVersion5 = uint16(5)
 
 	// CurrLatestTableInfoVersion means the latest table info in the current TiDB.
-	CurrLatestTableInfoVersion = TableInfoVersion4
+	CurrLatestTableInfoVersion = TableInfoVersion5
 )
 
 // ExtraHandleName is the name of ExtraHandle Column.

--- a/model/model.go
+++ b/model/model.go
@@ -289,6 +289,7 @@ type TableInfo struct {
 
 	Comment         string `json:"comment"`
 	AutoIncID       int64  `json:"auto_inc_id"`
+	AutoRowID       int64  `json:"auto_row_id"`
 	AutoIdCache     int64  `json:"auto_id_cache"`
 	AutoRandID      int64  `json:"auto_rand_id"`
 	MaxColumnID     int64  `json:"max_col_id"`

--- a/parser.y
+++ b/parser.y
@@ -531,6 +531,7 @@ import (
 	routine               "ROUTINE"
 	rowCount              "ROW_COUNT"
 	rowFormat             "ROW_FORMAT"
+	rowID                 "ROW_ID"
 	rtree                 "RTREE"
 	san                   "SAN"
 	second                "SECOND"
@@ -6066,6 +6067,7 @@ UnReservedKeyword:
 |	"CLUSTERED"
 |	"NONCLUSTERED"
 |	"PRESERVE"
+|	"ROW_ID"
 
 TiDBKeyword:
 	"ADMIN"
@@ -11110,6 +11112,10 @@ TableOption:
 	{
 		$$ = &ast.TableOption{Tp: ast.TableOptionCollate, StrValue: $4,
 			UintValue: ast.TableOptionCharsetWithoutConvertTo}
+	}
+|	ForceOpt "ROW_ID" EqOpt LengthNum
+	{
+		$$ = &ast.TableOption{Tp: ast.TableOptionRowID, UintValue: $4.(uint64), BoolValue: $1.(bool)}
 	}
 |	ForceOpt "AUTO_INCREMENT" EqOpt LengthNum
 	{

--- a/parser_test.go
+++ b/parser_test.go
@@ -3342,6 +3342,13 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"alter table t force auto_random_base = 50", true, "ALTER TABLE `t` FORCE AUTO_RANDOM_BASE = 50"},
 		{"alter table t auto_increment 30, force auto_random_base 40", true, "ALTER TABLE `t` AUTO_INCREMENT = 30, FORCE AUTO_RANDOM_BASE = 40"},
 
+		// for row id
+		{"create table t (a bigint primary key) row_id = 10", true, "CREATE TABLE `t` (`a` BIGINT PRIMARY KEY) ROW_ID = 10"},
+		{"alter table t row_id = 100", true, "ALTER TABLE `t` ROW_ID = 100"},
+		{"alter table t auto_increment 30, row_id 40", true, "ALTER TABLE `t` AUTO_INCREMENT = 30, ROW_ID = 40"},
+		{"alter table t force row_id = 50", true, "ALTER TABLE `t` FORCE ROW_ID = 50"},
+		{"alter table t auto_increment 30, force row_id 40", true, "ALTER TABLE `t` AUTO_INCREMENT = 30, FORCE ROW_ID = 40"},
+
 		// for alter sequence
 		{"alter sequence seq", false, ""},
 		{"alter sequence seq comment=\"haha\"", false, ""},

--- a/tidb/features.go
+++ b/tidb/features.go
@@ -28,6 +28,8 @@ const (
 	FeatureIDForceAutoInc = "force_inc"
 	// FeatureIDPlacement is the `placement rule` feature.
 	FeatureIDPlacement = "placement"
+	// FeatureIDRowID is the `row_id` table option feature.
+	FeatureIDRowID = "row_id"
 )
 
 var featureIDs = map[string]struct{}{
@@ -37,6 +39,7 @@ var featureIDs = map[string]struct{}{
 	FeatureIDClusteredIndex: {},
 	FeatureIDForceAutoInc:   {},
 	FeatureIDPlacement:      {},
+	FeatureIDRowID:          {},
 }
 
 func CanParseFeature(fs ...string) bool {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The parser part of https://github.com/pingcap/tidb/pull/28448.

### What is changed and how it works?

- Support syntax `alter table t modify [force] row_id = xxx`. This is useful in the last stage when importing with Lightning.
- Add a job action `ActionRebaseRowID`.
- Change `TableInfoVersion4` to `TableInfoVersion5`. `TableInfoVersion4` is a version that is equivalent to `TableInfoVersion3` for some reasons.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

NA

Side effects

NA

Related changes

NA