### PR TITLE
add support for charset utf8mb3, utf-16, utf-32

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -55,6 +55,8 @@ var charsetInfos = map[string]*Charset{
 	CharsetUTF8:    {CharsetUTF8, CollationUTF8, make(map[string]*Collation), "UTF-8 Unicode", 3},
 	CharsetUTF8MB3: {CharsetUTF8MB3, CollationUTF8MB3, make(map[string]*Collation), "UTF-8 Unicode", 3},
 	CharsetUTF8MB4: {CharsetUTF8MB4, CollationUTF8MB4, make(map[string]*Collation), "UTF-8 Unicode", 4},
+	CharsetUTF16:   {CharsetUTF16, CollationUTF16, make(map[string]*Collation), "UTF-16 Unicode", 4},
+	CharsetUTF32:   {CharsetUTF32, CollationUTF32, make(map[string]*Collation), "UTF-32 Unicode", 4},
 	CharsetASCII:   {CharsetASCII, CollationASCII, make(map[string]*Collation), "US ASCII", 1},
 	CharsetLatin1:  {CharsetLatin1, CollationLatin1, make(map[string]*Collation), "Latin1", 1},
 	CharsetBin:     {CharsetBin, CollationBin, make(map[string]*Collation), "binary", 1},
@@ -65,6 +67,8 @@ var supportedCollationNames = map[string]struct{}{
 	CollationUTF8:    {},
 	CollationUTF8MB3: {},
 	CollationUTF8MB4: {},
+	CollationUTF16:   {},
+	CollationUTF32:   {},
 	CollationASCII:   {},
 	CollationLatin1:  {},
 	CollationBin:     {},
@@ -112,7 +116,8 @@ func ValidCharsetAndCollation(cs string, co string) bool {
 // GetDefaultCollationLegacy is compatible with the charset support in old version parser.
 func GetDefaultCollationLegacy(charset string) (string, error) {
 	switch strings.ToLower(charset) {
-	case CharsetUTF8, CharsetUTF8MB3, CharsetUTF8MB4, CharsetASCII, CharsetLatin1, CharsetBin:
+	case CharsetUTF8, CharsetUTF8MB3, CharsetUTF8MB4, CharsetUTF16, CharsetUTF32, CharsetASCII,
+		CharsetLatin1, CharsetBin:
 		return GetDefaultCollation(charset)
 	default:
 		return "", errors.Errorf("Unknown charset %s", charset)
@@ -239,8 +244,12 @@ const (
 	CharsetUCS2     = "ucs2"
 	CharsetUJIS     = "ujis"
 	CharsetUTF16    = "utf16"
-	CharsetUTF16LE  = "utf16le"
-	CharsetUTF32    = "utf32"
+	// CollationUTF16 is the default collation for CharsetUTF16.
+	CollationUTF16 = "utf16_bin"
+	CharsetUTF16LE = "utf16le"
+	CharsetUTF32   = "utf32"
+	// CollationUTF32 is the default collation for CharsetUTF32.
+	CollationUTF32 = "utf32_bin"
 )
 
 var collations = []*Collation{
@@ -297,14 +306,14 @@ var collations = []*Collation{
 	{51, "cp1251", "cp1251_general_ci", true},
 	{52, "cp1251", "cp1251_general_cs", false},
 	{53, "macroman", "macroman_bin", false},
-	{54, "utf16", "utf16_general_ci", true},
-	{55, "utf16", "utf16_bin", false},
+	{54, "utf16", "utf16_bin", true},
+	{55, "utf16", "utf16_general_ci", false},
 	{56, "utf16le", "utf16le_general_ci", true},
 	{57, "cp1256", "cp1256_general_ci", true},
 	{58, "cp1257", "cp1257_bin", false},
 	{59, "cp1257", "cp1257_general_ci", true},
-	{60, "utf32", "utf32_general_ci", true},
-	{61, "utf32", "utf32_bin", false},
+	{60, "utf32", "utf32_bin", true},
+	{61, "utf32", "utf32_general_ci", false},
 	{62, "utf16le", "utf16le_bin", false},
 	{63, "binary", "binary", true},
 	{64, "armscii8", "armscii8_bin", false},

--- a/charset/charset_test.go
+++ b/charset/charset_test.go
@@ -47,7 +47,7 @@ func (s *testCharsetSuite) TestValidCharset(c *C) {
 		{"utf8mb4", "utf8mb4_bin", true},
 		{"latin1", "latin1_bin", true},
 		{"utf8", "utf8_invalid_ci", false},
-		{"utf16", "utf16_bin", false},
+		{"utf16", "utf16_bin", true},
 		{"gb2312", "gb2312_chinese_ci", false},
 		{"UTF8", "UTF8_BIN", true},
 		{"UTF8", "utf8_bin", true},
@@ -57,6 +57,12 @@ func (s *testCharsetSuite) TestValidCharset(c *C) {
 		{"UTF8MB4", "UTF8MB4_bin", true},
 		{"UTF8MB4", "UTF8MB4_general_ci", true},
 		{"Utf8", "uTf8_bIN", true},
+		{"UTF16", "UTF16_BIN", true},
+		{"UTF16", "utf16_bin", true},
+		{"Utf16", "uTf16_bIN", true},
+		{"UTF32", "UTF32_BIN", true},
+		{"UTF32", "utf32_bin", true},
+		{"Utf32", "uTf32_bIN", true},
 	}
 	for _, tt := range tests {
 		testValidCharset(c, tt.cs, tt.co, tt.succ)
@@ -99,6 +105,10 @@ func (s *testCharsetSuite) TestGetDefaultCollation(c *C) {
 		{"UTF8", "utf8_bin", true},
 		{"utf8mb3", "utf8mb3_bin", true},
 		{"utf8mb4", "utf8mb4_bin", true},
+		{"utf16", "utf16_bin", true},
+		{"UTF16", "utf16_bin", true},
+		{"utf32", "utf32_bin", true},
+		{"UTF32", "utf32_bin", true},
 		{"ascii", "ascii_bin", true},
 		{"binary", "binary", true},
 		{"latin1", "latin1_bin", true},
@@ -148,6 +158,10 @@ func (s *testCharsetSuite) TestGetCharsetDesc(c *C) {
 	}{
 		{"utf8", "utf8", true},
 		{"UTF8", "utf8", true},
+		{"utf16", "utf16", true},
+		{"UTF16", "utf16", true},
+		{"utf32", "utf32", true},
+		{"UTF32", "utf32", true},
 		{"utf8mb3", "utf8mb3", true},
 		{"utf8mb4", "utf8mb4", true},
 		{"ascii", "ascii", true},
@@ -167,7 +181,6 @@ func (s *testCharsetSuite) TestGetCharsetDesc(c *C) {
 }
 
 func (s *testCharsetSuite) TestGetCollationByName(c *C) {
-
 	for _, collation := range collations {
 		coll, err := GetCollationByName(collation.Name)
 		c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read [this](https://github.com/pingcap/parser/blob/master/README.md) document **BEFORE** filing this PR.
-->

### not support utf8mb3 charset now


### add support of utf8mb3 charset

Tests <!-- At least one of them must be included. -->

 - Unit test
 